### PR TITLE
Add options to make a bar chart display as percentage

### DIFF
--- a/server/plugin/resource/resources/custom/components/CCC/component.xml
+++ b/server/plugin/resource/resources/custom/components/CCC/component.xml
@@ -526,6 +526,7 @@
           <Property name="timeSeriesFormat">cccTimeSeriesFormat</Property>
 
           <Property name="stacked">cccStacked</Property>
+          <Property name="percentage">cccPercentage</Property>
           <Property name="maxBarSize">cccMaxBarSize</Property>
           <Property name="panelSizeRatio">cccPanelSizeRatio</Property>
           <Property name="barSizeRatio">cccBarSizeRatio</Property>

--- a/server/plugin/resource/resources/custom/properties/CCC/property.xml
+++ b/server/plugin/resource/resources/custom/properties/CCC/property.xml
@@ -72,6 +72,20 @@
   </DesignerProperty>
   <DesignerProperty>
     <Header>
+      <Name>cccPercentage</Name>
+      <Parent>BaseProperty</Parent>
+      <DefaultValue>"false"</DefaultValue>
+      <Description>Percentage</Description>
+      <Tooltip>Stacked Chart Displays by Percentage?</Tooltip>
+      <InputType>Boolean</InputType>
+      <OutputType>Boolean</OutputType>
+      <Order>42</Order>
+      <Advanced>true</Advanced>
+      <Version>1.0</Version>
+    </Header>
+  </DesignerProperty>
+  <DesignerProperty>
+    <Header>
       <Name>cccMaxBarSize</Name>
       <Parent>BaseProperty</Parent>
       <DefaultValue>100</DefaultValue>


### PR DESCRIPTION
This goes along with the ccc pull request I just made; it allows a user to define a stacked bar chart to display values as a percentage of the total.
