### PR TITLE
fixing a small issue when choosing existing saiku queries

### DIFF
--- a/client/js/cdf-dd-wizardmanager.js
+++ b/client/js/cdf-dd-wizardmanager.js
@@ -176,7 +176,7 @@ var SaikuOlapWizard = WizardManager.extend({
     			var action = splitFile[splitFile.length -1];
     			var path = "";
     			if (splitFile.length > 3) {
-    				for (var i= 1; i < splitFile.length -1; i++) {
+    				for (var i= 2; i < splitFile.length -1; i++) {
     					path += "/" + splitFile[i];
     				}
     			}


### PR DESCRIPTION
when the existing saiku query wasn't in the root directory of a solution it would fail.
i constructed the path from the wrong index

works now
