### PR TITLE
Allow Icons to be downloaded.

### DIFF
--- a/server/plugin/resource/settings.xml
+++ b/server/plugin/resource/settings.xml
@@ -3,7 +3,7 @@
   <cache>false</cache>
   <max-age>2628000</max-age>
   <resources>
-      <downloadable-formats>css,js,html,htm,png,jpg,jpeg,gif,swf,htc,otf,woff</downloadable-formats>
+      <downloadable-formats>css,js,html,htm,png,jpg,jpeg,gif,swf,htc,otf,woff,ico</downloadable-formats>
   </resources>
   <packager>
     <minification>MINIFY</minification>


### PR DESCRIPTION
Allow Icons to be downloaded, in case Dashboard Designer wants to set a favicon, for example.
