### PR TITLE
Plugin Styles not listed due to missing "/" before FileExists control

### DIFF
--- a/cde-pentaho-base/src/pt/webdetails/cdf/dd/cdf/CdfStyles.java
+++ b/cde-pentaho-base/src/pt/webdetails/cdf/dd/cdf/CdfStyles.java
@@ -55,7 +55,7 @@ public class CdfStyles {
     for ( PluginsAnalyzer.PluginWithEntity entity : entities ) {
 
       String pluginStylesDir = entity.getRegisteredEntity().valueOf( "path" );
-      String finalPath = pluginStylesDir + "/";
+      String finalPath = "/" + pluginStylesDir + "/";
       String pluginId = entity.getPlugin().getId();
       style = null;
 


### PR DESCRIPTION
FileExists method fails because for system resourse it checks for paths like /system not just system 
