### PR TITLE
[SERVDEV-24]

### DIFF
--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/Component.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/Component.java
@@ -197,6 +197,14 @@ public abstract class Component<TM extends ComponentType> extends Instance<TM>
     return propBind;
   }
 
+  public String tryGetPropertyValueByName( String name, String defaultValue)
+  {
+    PropertyBinding bind = this.tryGetPropertyBindingByName( name );
+    return bind == null ?
+      defaultValue :
+      StringUtils.defaultIfEmpty(bind.getValue(), defaultValue);
+  }
+
   public PropertyBinding tryGetPropertyBinding(String alias)
   {
     if(StringUtils.isEmpty(alias)) { throw new IllegalArgumentException("alias"); }

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/properties/CdfRunJsDataSourcePropertyBindingWriter.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/properties/CdfRunJsDataSourcePropertyBindingWriter.java
@@ -199,10 +199,10 @@ public class CdfRunJsDataSourcePropertyBindingWriter extends CdfRunJsPropertyBin
     String pluginId = buildJsStringValue( compType.tryGetAttributeValue( PropertyName.PLUGIN_ID, "" ) );
     addJsProperty( out, PropertyName.PLUGIN_ID, pluginId, indent, false );
 
-    String stepName = dataSourceComp.getPropertyBindingByName( PropertyName.KETTLE_OUTPUT_STEP_NAME ).getValue();
+    String stepName = dataSourceComp.tryGetPropertyValueByName( PropertyName.KETTLE_OUTPUT_STEP_NAME, "OUTPUT" );
     addJsProperty( out, PropertyName.KETTLE_OUTPUT_STEP_NAME, buildJsStringValue( stepName ), indent, false );
 
-    String kettleOutput = dataSourceComp.getPropertyBindingByName( PropertyName.KETTLE_OUTPUT_FORMAT ).getValue();
+    String kettleOutput = dataSourceComp.tryGetPropertyValueByName( PropertyName.KETTLE_OUTPUT_FORMAT, "Infered" );
     addJsProperty( out, PropertyName.KETTLE_OUTPUT_FORMAT, buildJsStringValue( kettleOutput ), indent, false );
 
     addJsProperty( out, PropertyName.QUERY_TYPE, JsonUtils.toJsString( PropertyValue.CPK_QUERY_TYPE ), indent, false );


### PR DESCRIPTION
- Corrected bug on CDE render cpm datasources where the render failed when the stepName and kettleOutput property bindings were not defined.

@pamval please review
