### PR TITLE
[CDE-210] Style "Clean" currently does not support i18n

### DIFF
--- a/cde-core/resource/resources/styles/Clean.html
+++ b/cde-core/resource/resources/styles/Clean.html
@@ -5,6 +5,27 @@
 		@HEADER@
 	</head>
 	<body>
+		<script language="javascript">
+			// Init jQuery i18n plugin
+			loadMessageBundles = function(lang) {
+				jQuery.i18n.properties({
+					name:'#{GLOBAL_MESSAGE_SET_NAME}',
+					path:'#{GLOBAL_MESSAGE_SET_PATH}',
+					mode:'both',
+					language:(lang == 'browser' ? jQuery.i18n.browserLang() : lang),
+					callback: function() {
+						#{GLOBAL_MESSAGE_SET}
+					}
+				});
+				Dashboards.setI18nSupport('#{LANGUAGE_CODE}', jQuery.i18n);
+			}
+
+			$(document).ready(function(){
+				// Initialize jquery.i18n plugin - load message files
+				var userLocale = '#{LANGUAGE_CODE}';
+				loadMessageBundles(userLocale);
+			});
+		</script>
 	
 		@CONTENT@
 		

--- a/cde-core/src/pt/webdetails/cdf/dd/localization/MessageBundlesHelper.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/localization/MessageBundlesHelper.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Locale;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -15,6 +16,7 @@ import pt.webdetails.cpf.repository.api.IBasicFile;
 import pt.webdetails.cpf.repository.api.IRWAccess;
 import pt.webdetails.cpf.repository.api.IReadAccess;
 import pt.webdetails.cpf.repository.api.IUserContentAccess;
+import pt.webdetails.cpf.repository.util.RepositoryHelper;
 
 public class MessageBundlesHelper {
 
@@ -43,7 +45,11 @@ public class MessageBundlesHelper {
 
     this.staticBaseContentUrl = CdeEngine.getEnv().getExtApi().getPluginStaticBaseUrl();
 
-    this.msgsRelativeDir = msgsRelativeDir;
+    if( StringUtils.isEmpty( msgsRelativeDir ) ){
+      this.msgsRelativeDir = String.valueOf( RepositoryHelper.SEPARATOR );
+    } else if( !msgsRelativeDir.startsWith( String.valueOf( RepositoryHelper.SEPARATOR ) ) ){
+      this.msgsRelativeDir = String.valueOf( RepositoryHelper.SEPARATOR ) + msgsRelativeDir;
+    }
     this.sourceDashboardBaseMsgFile = sourceDashboardBaseMsgFile;
     this.languagesCacheUrl = Utils.joinPath( staticBaseContentUrl, BASE_CACHE_DIR, msgsRelativeDir );
   }


### PR DESCRIPTION
```
- also: ensured MessagesBundleHelper's relativeDir always starts path with '/'
```
