### PR TITLE
[CDE-240]: added explanation to why jquery v1.4.4 is still being used

### DIFF
--- a/cde-core/resource/resources/ext-editor.html
+++ b/cde-core/resource/resources/ext-editor.html
@@ -38,6 +38,7 @@
     <meta charset="UTF-8">
     <title>Editor</title>
     <!--jquery -->
+    <!-- Using jquery v1.4.4 because of IE8. When using newer versions like v1.7.1 IE8 forces compability mode and breaks CDE -->
     <script language="javascript" type="text/javascript" src="@CDE_RESOURCES_BASE_URL@/js/jquery.js"></script>
     
     <!-- CDF files -->


### PR DESCRIPTION
@pamval please review
