### PR TITLE
[CDE-129]: Refix context to resources url in run-time

### DIFF
--- a/cde-pentaho/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/PentahoCdfRunJsDashboardWriteContext.java
+++ b/cde-pentaho/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/PentahoCdfRunJsDashboardWriteContext.java
@@ -7,34 +7,40 @@ import pt.webdetails.cdf.dd.model.inst.Dashboard;
 public class PentahoCdfRunJsDashboardWriteContext extends CdfRunJsDashboardWriteContext {
 
   public PentahoCdfRunJsDashboardWriteContext( IThingWriterFactory factory,
-      String indent, boolean bypassCacheRead, Dashboard dash,
-      CdfRunJsDashboardWriteOptions options ) {
+                                               String indent, boolean bypassCacheRead, Dashboard dash,
+                                               CdfRunJsDashboardWriteOptions options ) {
     super( factory, indent, bypassCacheRead, dash, options );
   }
+
   public PentahoCdfRunJsDashboardWriteContext( CdfRunJsDashboardWriteContext factory,
-      String indent) {
-    super(factory,indent);
+                                               String indent ) {
+    super( factory, indent );
   }
 
 
   @Override
-  public String replaceTokens(String content) {
+  public String replaceTokens( String content ) {
     final long timestamp = this._writeDate.getTime();
 
-    final String root = this._options.isAbsolute() ?
-        (this._options.getSchemedRoot() + CdeEngine.getInstance().getEnvironment().getApplicationBaseContentUrl()) : "";
+    final String root = this._options.isAbsolute()
+      ? ( this._options.getSchemedRoot() + CdeEngine.getInstance().getEnvironment().getApplicationBaseContentUrl() )
+      : "";
 
 
-    final String path = this._dash.getSourcePath().replaceAll("(.+/).*", "$1");
+    final String path = this._dash.getSourcePath().replaceAll( "(.+/).*", "$1" );
 
     return content
-        .replaceAll( DASHBOARD_PATH_TAG, path.replaceAll( "(^/.*/$)", "$1" ) ) // replace the dashboard path token
-        .replaceAll( ABS_IMG_TAG, root + "res$1" + "?v=" + timestamp )// build the image links, with a timestamp for caching purposes
-        .replaceAll( REL_IMG_TAG, root + "res" + path + "$1" + "?v=" + timestamp )// build the image links, with a timestamp for caching purposes
-        .replaceAll( ABS_DIR_RES_TAG, root + "res$1" )// Directories don't need the caching timestamp
-        .replaceAll( REL_DIR_RES_TAG, root + "res" + path + "$1" )// Directories don't need the caching timestamp
-        .replaceAll( ABS_RES_TAG, root + "res$1" + "?v=" + timestamp )// build the image links, with a timestamp for caching purposes
-        .replaceAll( REL_RES_TAG, root + "res" + path + "$1" + "?v=" + timestamp );// build the image links, with a timestamp for caching purposes
+      .replaceAll( DASHBOARD_PATH_TAG, path.replaceAll( "(^/.*/$)", "$1" ) ) // replace the dashboard path token
+      .replaceAll( ABS_IMG_TAG,
+        root + "res$1" + "?v=" + timestamp )// build the image links, with a timestamp for caching purposes
+      .replaceAll( REL_IMG_TAG,
+        root + "res" + path + "$1" + "?v=" + timestamp )// build the image links, with a timestamp for caching purposes
+      .replaceAll( ABS_DIR_RES_TAG, root + "res$2" )// Directories don't need the caching timestamp
+      .replaceAll( REL_DIR_RES_TAG, root + "res" + path + "$2" )// Directories don't need the caching timestamp
+      .replaceAll( ABS_RES_TAG,
+        root + "res$2" + "?v=" + timestamp )// build the image links, with a timestamp for caching purposes
+      .replaceAll( REL_RES_TAG, root
+        + "res" + path + "$2" + "?v=" + timestamp ); // build the image links, with a timestamp for caching purposes
   }
 
 }

--- a/cde-pentaho5/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/PentahoCdfRunJsDashboardWriteContext.java
+++ b/cde-pentaho5/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/PentahoCdfRunJsDashboardWriteContext.java
@@ -46,12 +46,12 @@ public class PentahoCdfRunJsDashboardWriteContext extends CdfRunJsDashboardWrite
         + timestamp ) // build the image links, with a timestamp for caching purposes
       .replaceAll( REL_IMG_TAG, root + RESOURCE_API_GET + path + "$1" + "?v="
         + timestamp ) // build the image links, with a timestamp for caching purposes
-      .replaceAll( ABS_DIR_RES_TAG, root + RESOURCE_API_GET + "$1" ) // Directories don't need the caching timestamp
+      .replaceAll( ABS_DIR_RES_TAG, root + RESOURCE_API_GET + "$2" ) // Directories don't need the caching timestamp
       .replaceAll( REL_DIR_RES_TAG,
-        root + RESOURCE_API_GET + path + "$1" )// Directories don't need the caching timestamp
-      .replaceAll( ABS_RES_TAG, root + RESOURCE_API_GET + "$1" + "?v="
+        root + RESOURCE_API_GET + path + "$2" )// Directories don't need the caching timestamp
+      .replaceAll( ABS_RES_TAG, root + RESOURCE_API_GET + "$2" + "?v="
         + timestamp )// build the image links, with a timestamp for caching purposes
-      .replaceAll( REL_RES_TAG, root + RESOURCE_API_GET + path + "$1" + "?v="
+      .replaceAll( REL_RES_TAG, root + RESOURCE_API_GET + path + "$2" + "?v="
         + timestamp ) // build the image links, with a timestamp for caching purposes
       .replaceAll( ABS_SYS_RES_TAG, root + RESOURCE_API_GET + "/" + getSystemDir() + "/" + getPluginId( path )
         + "$1" + "?v=" + timestamp ) //build system resources links, with a timestamp for caching purposes
@@ -71,10 +71,14 @@ public class PentahoCdfRunJsDashboardWriteContext extends CdfRunJsDashboardWrite
   }
 
   protected String getPluginId( String path ) {
-    if ( path.charAt( 0 ) != '/' ) {
-      return path.split( "/" )[1];
+    if ( path.startsWith( "/" ) ) {
+      path = path.replaceFirst( "/", "" );
+    }
+
+    if ( path.startsWith( getSystemDir() ) ) {
+      return path.split( "/" )[ 1 ];
     } else {
-      return path.split( "/" )[2];
+      return "";
     }
   }
 


### PR DESCRIPTION
The previous commit broke CDE when you saved the dashboard, when in pentaho5, in a directory like "/public", and it wasn't building the resource url correctly, giving the tag name instead of the file name
@diogofscmariano please review 
