### PR TITLE
[CDE-273] CDE folder structure creation in not being triggered at startu...

### DIFF
--- a/cde-core/src/pt/webdetails/cdf/dd/CdeEngine.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/CdeEngine.java
@@ -72,6 +72,7 @@ public class CdeEngine {
       }
 
       instance.cdeEnv = env;
+      instance.ensureBasicDirs();
     }
   }
 

--- a/cde-pentaho-base/src/pt/webdetails/cdf/dd/CdeLifeCycleListener.java
+++ b/cde-pentaho-base/src/pt/webdetails/cdf/dd/CdeLifeCycleListener.java
@@ -42,7 +42,22 @@ public class CdeLifeCycleListener extends SimpleLifeCycleListener {
   @Override
   public void loaded() throws PluginLifecycleException {
     super.loaded();
-    CdeEngine.getInstance().ensureBasicDirs();
+    //CdeEngine.getInstance().ensureBasicDirs();
+
+    /**
+     * IMPORTANT: ensureBasicDirs() functionality was working in 5.0.1 but stopped working in 5.1.0;
+     *
+     * This is because in 5.1.0 's pentaho-solutions/system/systemListeners.xml
+     * bean SecuritySystemListener (responsible for booting up AuthenticationProvider)
+     * is being declared AFTER pluginSystemListener.
+     *
+     * Therefore, if by any chance a plugin desires to access the repository ON STARTUP using a login such as
+     * SecurityHelper.getInstance().runAsSystem(), it will be faced with a InvalidLoginCredentials exception
+     *
+     * Dev/Testing solution:
+     *
+     * in pentaho-solutions/system/systemListeners.xml place bean SecuritySystemListener BEFORE pluginSystemListener
+     */
   }
 
 


### PR DESCRIPTION
...p, but only upon first CDE Environment instantiation

```
- although the latest modifications were working properly in 5.0.1, they are not working in latest 5.1.0, therefore a regression will be made until such a point in time where we will get it back to work also for 5.1.0
- basic did creation now assume the old/deprecated solution: create them ( if not exist ) only on first CDE dashboard access ( and not on startup, in CdeLifecycleListener)
- placed detailed comments near the (now) commented code
```
