### PR TITLE
[CDE-339] Custom parameters break when the value is a string

### DIFF
--- a/cde-core/resource/js/cdf-dd-prompt-wizard.js
+++ b/cde-core/resource/js/cdf-dd-prompt-wizard.js
@@ -319,6 +319,18 @@ var JavascriptWizard = AcePromptWizard.extend({
 		
 		getFunctionValue: function(_function){
 			return _function.value;
+		},
+
+		apply: function(){
+			var value = this.editor.getContents();
+
+			// set value. We need to add a space to prevent a string like function(){}
+			// to be interpreted by json as a function instead of a string
+			if(value && value.length != 0 && value.substr(value.length-1,1)!=" "){
+				value = value+" ";
+			}
+
+			this.invoker.promptCallback(value);
 		}
 		
 	},{


### PR DESCRIPTION
```
- PrompWizard defines an apply() function where a whitespace is being added to the end of a string value ( @see https://github.com/webdetails/cde/blob/master/cde-core/resource/js/cdf-dd-prompt-wizard.js#L159-L169 )
- AcePromptWizard extends PrompWizard and overrides apply() function to read the value from its appropriate place, *but* did not include that whitespace addition
```
