### PR TITLE
[CDE-395] When a new dashboard is created, the renderer type should be b...

### DIFF
--- a/cde-core/resource/js/cdf-dd-layout.js
+++ b/cde-core/resource/js/cdf-dd-layout.js
@@ -50,7 +50,7 @@ var LayoutPanel = Panel.extend({
             this.treeTable = new TableManager(LayoutPanel.TREE);
             this.treeTable.setTitle("Layout Structure");
 
-            var dashboardType = cdfdd.dashboardWcdf.rendererType || "blueprint";
+            var dashboardType = cdfdd.dashboardWcdf.rendererType || "bootstrap";
             this.treeTable.setInitialOperations(operationSets[dashboardType]);
 
             var treeTableModel = new TableModel('layoutTreeTableModel');

--- a/cde-core/resource/resources/empty.wcdf
+++ b/cde-core/resource/resources/empty.wcdf
@@ -5,4 +5,5 @@
         <description>@DASBOARD_DESCRIPTION@</description>
         <icon></icon>
 		<style></style>
+		<rendererType>bootstrap</rendererType>
 </cdf>


### PR DESCRIPTION
...ootstrap by default

```
- empty.wcdf ( read: the wcdf that holds the basic parameters for a new dashboard ) now includes the rendererType ( set to 'bootstrap' )
- updated cde-core's cdf-dd-layout failsafe mechanism for rendererType definition from 'blueprint' to 'dashboard'
- documentation @ http://redmine.webdetails.org/projects/cde/wiki/Setting_up_the_default_renderer_for_new_CDE_Dashboards
```
