### PR TITLE
[CDE-440] - Olap selector component's addPreSelectValues function fails to calculate depth when a qualifiedName contains the '.' char

### DIFF
--- a/cde-core/resource/resources/custom/components/OlapSelector/OlapSelector.css
+++ b/cde-core/resource/resources/custom/components/OlapSelector/OlapSelector.css
@@ -20,7 +20,7 @@
   overflow-y: hidden;
 }
 .olapSelectorComponent .pulldown {
-  width: 280px;
+  width: 180px;
   position: relative;
   padding-bottom: 4px;
   border-bottom: 2px solid #969b9e;
@@ -29,7 +29,7 @@
   width: 800px;
   position: absolute;
   top: -2px;
-  left: 282px;
+  left: 182px;
   overflow: hidden;
   background-color: white;
   border: 2px solid #047eca;
@@ -419,12 +419,12 @@
   line-height: 25px;
 }
 .olapSelectorComponent.collapsed .pulldown div.title {
-  width: 263px;
+  width: 163px;
   height: 25px;
   line-height: 23px;
 }
 .olapSelectorComponent .pulldown div.title {
-  width: 262px;
+  width: 162px;
   height: 25px;
   line-height: 23px;
   position: relative;

--- a/cde-core/resource/resources/custom/components/OlapSelector/OlapSelector.js
+++ b/cde-core/resource/resources/custom/components/OlapSelector/OlapSelector.js
@@ -1,6 +1,6 @@
 /*
  * Selector Model describes the behaviour for the selector
- * as a whole. 
+ * as a whole.
  */
 
 var wd = wd || {};
@@ -33,7 +33,7 @@ var OlapSelectorModel = Backbone.Model.extend({
     },
 
     initialize: function() {
-      
+
       var values = new Backbone.Collection();
       this.set("values",values);
       values.comparator = function(left, right) {
@@ -58,7 +58,7 @@ var OlapSelectorModel = Backbone.Model.extend({
       this.setupEvents();
       this.preSelectValues();
     },
-    
+
     preSelectValues: function() {
       var myself = this,
           olapUtils = this.get("olapUtils"),
@@ -78,7 +78,7 @@ var OlapSelectorModel = Backbone.Model.extend({
           var toChange = myself.processPreSelectValues(v.members, defaultSelect);
 
           myself.addPreSelectValues(toChange, myself);
-   
+
         });
       }
     },
@@ -87,7 +87,7 @@ var OlapSelectorModel = Backbone.Model.extend({
       var values = [],
           selectedLevelDepth = this.getSelectedLevels().at(0).get("depth"),
           memberDepth;
-          
+
       if(!defaultVals.length)  {
         return members;
       }
@@ -115,10 +115,11 @@ var OlapSelectorModel = Backbone.Model.extend({
 
       for (c = 0; c < toChange.length; c++) {
         var newValue = toChange[c], depth;
-              
-        depth = (newValue.qualifiedName.split(".").length - 2);
+
+        depth = newValue.qualifiedName.match(/(\[[^\]]+]\.?)/g).length - 2;
+
         newValue.level = myself.get("levels").at(depth).id;
-              
+
         values.add(newValue, {
           silent: true
         });
@@ -130,9 +131,9 @@ var OlapSelectorModel = Backbone.Model.extend({
     updateLevels: function(){
       var olapUtils = this.get("olapUtils"),
       h = olapUtils.getHierarchy();
-      
+
       if (h.hasAll){
-          
+
           var allMember = {
               name: h.defaultMember,
               qualifiedName: h.defaultMemberQualifiedName,
@@ -140,20 +141,20 @@ var OlapSelectorModel = Backbone.Model.extend({
           }
           this.get("levels").add(allMember);
       }
-      
+
       this.get("levels").add(olapUtils.getLevels(),{
           silent:true
       });
     },
-    
+
     processLevelSelection: function(evt){
       // Make sure there's one and only one selected
       if(this.getSelectedLevels().length == 0){
-          
+
           if(evt == null){
               this.get("levels").at(0).set({
                   "selected":true
-              });                    
+              });
           }
           else{
               evt.set({
@@ -162,9 +163,9 @@ var OlapSelectorModel = Backbone.Model.extend({
           }
           return; // we'll be back
       }
-      
+
       if(this.getSelectedLevels().size() > 1){
-          
+
           _(this.getSelectedLevels().without(evt)).each(function(f){
               f.set({
                   selected:false
@@ -232,7 +233,7 @@ var OlapSelectorModel = Backbone.Model.extend({
         defaultQualified = olapUtils.getHierarchy().defaultMemberQualifiedName,
         atTopLevel,
         selectedLevel = levels.where({selected:true})[0],
-        qualifiedName = selectedLevel.get("qualifiedName"), 
+        qualifiedName = selectedLevel.get("qualifiedName"),
         idx = levels.indexOf(selectedLevel);
       selectedLevel.set("selected",false);
       atTopLevel =  qualifiedName == defaultQualified;
@@ -288,7 +289,7 @@ var OlapSelectorModel = Backbone.Model.extend({
       if(breadcrumb && breadcrumb.length) {
         var l = breadcrumb.length - 1;
         options.startMember = breadcrumb[l].get("qualifiedName");
-      } 
+      }
       level = selectedLevel ? selectedLevel.get("name") : "";
       if(!level || level == olapUtils.getHierarchy().defaultMember) {
         options.level = olapUtils.getLevels()[0].name;
@@ -320,7 +321,7 @@ var OlapSelectorModel = Backbone.Model.extend({
         values = this.get("values");
         for(v = 0; v < newValues.length;v++) {
           var newValue = newValues[v],
-              found;  
+              found;
           newValue.level = this.getSelectedLevels().at(0).get("qualifiedName");
           found = values.detect(function(model){
             return model.get("level") == newValue.level &&
@@ -366,13 +367,13 @@ var OlapSelectorModel = Backbone.Model.extend({
     lastPage: function() {
         var total = this.get("totalRecords"),
         size = this.get("pageSize");
-        this.set("pageStart", total - total % size);   
+        this.set("pageStart", total - total % size);
       this.trigger("page");
     },
 
     goToPage: function(page) {
       var size = this.get("pageSize");
-      this.set("pageStart", page * size);   
+      this.set("pageStart", page * size);
       this.trigger("page");
     },
 
@@ -400,7 +401,7 @@ var OlapSelectorModel = Backbone.Model.extend({
             if(!isMultiselect) {
               other.set("selected",false);
             }
-            /* Chosing both an element and its children can cause double-counting 
+            /* Chosing both an element and its children can cause double-counting
              * issues so we should deselect the child elements if the option for
              * deselectDescendants is set on the component.
              */
@@ -447,7 +448,7 @@ var OlapSelectorModel = Backbone.Model.extend({
 
 /*
  * Option Model describes the behaviour for each individual
- * option within the selector.  
+ * option within the selector.
  */
 var OptionModel = Backbone.Model.extend({
     defaults: {
@@ -465,11 +466,11 @@ var OptionModel = Backbone.Model.extend({
 });
 
 var LevelModel = OptionModel.extend({
-   
+
     defaults: {},
-    
+
     initialize: function(o){
-    
+
         // Bind changing qualifiedName to id and name to value
         this.on("change:qualifiedName change:name",function(o){
             wd.log("Detected changes");
@@ -478,9 +479,9 @@ var LevelModel = OptionModel.extend({
         });
         this.set("id",this.get("qualifiedName"));
         this.set("label",this.get("name"));
-        
+
     }
-    
+
 });
 
 
@@ -513,7 +514,7 @@ var OlapSelectorView = Backbone.View.extend({
     },
 
     initialize: function() {
-    
+
         this.initializeOptions();
         this.configureListeners();
         this.levelViews = [];
@@ -549,11 +550,11 @@ var OlapSelectorView = Backbone.View.extend({
                 this._selectedViewsOut.push(new SelectionViewOut({
                     model:m
                 }));
-            } 
+            }
         }, this);
 
     },
-    
+
     updateSearch: function(evt) {
         this.model.set("searchterm", evt.target.value);
     },
@@ -633,7 +634,7 @@ var OlapSelectorView = Backbone.View.extend({
         drillVisible = drillTerm == null || model.get("qualifiedName").indexOf(drillTerm.get("qualifiedName")) > -1;
       return levelVisible && searchVisible && drillVisible;
     },
-  
+
     highlightParents: function() {
       var parentModel = this.model,
           selectedMembers = parentModel.get("values").where({selected:true}).map(function(m){return m.get("qualifiedName");});
@@ -643,8 +644,8 @@ var OlapSelectorView = Backbone.View.extend({
             .without(v.model.get("qualifiedName"))
             .filter(function(m){return m.indexOf(name) > -1;})
             .value();
-        /* 
-         * childrenSelected will always have at least the 
+        /*
+         * childrenSelected will always have at least the
          * member itself, so we need to check that length > 1
          */
         v.$el.toggleClass("highlight",childrenSelected.length > 0);
@@ -664,7 +665,7 @@ var OlapSelectorView = Backbone.View.extend({
             });
             this.$el.find(".leftArea .selection").append(vInner.render().el);
             this._selectedViews.push(vInner);
-         
+
             vOuter = new SelectionViewOut({
                 model:m
             });
@@ -708,7 +709,7 @@ var OlapSelectorView = Backbone.View.extend({
     },
 
     updateCollapsed: function() {
-  
+
         $('.olapSelectorComponent').addClass('collapsed').removeClass('expanded');
         if (this.model.get("collapsed")) {
             this.$el.find('.olapSelectorComponent').addClass('collapsed').removeClass('expanded');
@@ -765,11 +766,11 @@ var OptionView = Backbone.View.extend({
         this.setTemplate();
         this.model.on("change:selected",this.updateSelectionDisplay,this);
     },
-    
+
     setTemplate: function(){
         this.template = templates.olapSelector.option
     },
-    
+
     drillDown: function() {
       var val = this.model.get("drill");
       this.model.set("drill", !val);
@@ -802,7 +803,7 @@ var LevelView = OptionView.extend({
 
     tagName: "span",
     template: null,
-    
+
     setTemplate: function(){
         this.template = templates.olapSelector.level;
     }
@@ -844,7 +845,7 @@ var SelectionViewOut = SelectionView.extend({
     }
 });
 
-/* 
+/*
  * TEMPLATES
  */
 
@@ -857,14 +858,14 @@ templates.olapSelector.main = Mustache.compile(
     "     <div class='optionList'>"+
     "       <div class='leftArea'>" +
     "         <div class='header'>Select Level</div>" +
-    "         <div class='levels'></div>" + 
+    "         <div class='levels'></div>" +
     "         <div class='selectionPanel'>" +
     "           <div class='label'>Selected Filters</div>" +
     "           <ul class='selection'></ul>" +
-    "         </div>" + 
+    "         </div>" +
     "       </div>" +
-    "       <div class='rightArea {{#paginate}}paginate{{/paginate}}'>" + 
-    "         <div class='header'>" + 
+    "       <div class='rightArea {{#paginate}}paginate{{/paginate}}'>" +
+    "         <div class='header'>" +
     /* Don't touch the indentation! Indentating this
      * would create some pretty annoying text nodes
      */

--- a/cde-core/resource/resources/custom/components/OlapSelector/OlapSelector.less
+++ b/cde-core/resource/resources/custom/components/OlapSelector/OlapSelector.less
@@ -26,7 +26,7 @@
  */
 .olapSelectorComponent {
   font-family: Trebuchet, Helvetica, Arial, sans-serif;
-  
+
   &.collapsed {
     .optionList {
       height: 0px;
@@ -37,7 +37,7 @@
       }
     }
   }
-  
+
   &.expanded {
     .selection {
       height: 0px;
@@ -46,7 +46,7 @@
   }
 
   .pulldown {
-    width: 280px;
+    width: 180px;
     position: relative;
     padding-bottom: 4px;
     border-bottom: 2px solid #969b9e;
@@ -55,7 +55,7 @@
       width: 800px;
       position: absolute;
       top: -2px;
-      left: 282px;
+      left: 182px;
       overflow: hidden;
       background-color: white;
       border: 2px solid @selectorBlue;
@@ -143,7 +143,7 @@
             border: 1px solid silver;
             border-radius: 4px;
             position: relative;
-          
+
             &:hover {
               border: solid 1px @selectorBlue;
             }
@@ -320,7 +320,7 @@
 }
 
 .olapSelectorComponent .selection .item{
-    margin: 2px 0px;  
+    margin: 2px 0px;
 }
 
 .olapSelectorComponent .optionList .item{
@@ -438,14 +438,14 @@
 }
 
 .olapSelectorComponent.collapsed .pulldown div.title {
-    width: 263px;
+    width: 163px;
     height: 25px;
     line-height: 23px;
 
 }
 
 .olapSelectorComponent .pulldown div.title {
-    width:262px;
+    width:162px;
     height: 25px;
     line-height: 23px;
     position: relative;

--- a/cde-core/resource/resources/custom/components/OlapSelector/OlapSelectorComponent.js
+++ b/cde-core/resource/resources/custom/components/OlapSelector/OlapSelectorComponent.js
@@ -78,7 +78,9 @@ var OlapSelectorComponent = BaseComponent.extend({
     var paramValue = Dashboards.getParameterValue(param),
         values = [];
 
-    if(typeof paramValue !== 'undefined') {
+    if(typeof paramValue !== 'undefined'
+      && paramValue.length > 0) {
+      
       values = JSON.parse(paramValue);
       if(!this.multiSelect) {
         values = new Array(values[0]);

--- a/cde-pentaho5/solution/pentaho-cdf-dd/tests/OlapSelector/index.locale
+++ b/cde-pentaho5/solution/pentaho-cdf-dd/tests/OlapSelector/index.locale
@@ -1,0 +1,3 @@
+#Locale = default
+file.title=Olap Selector
+file.description=Olap Selector Component sample

--- a/cde-pentaho5/solution/pentaho-cdf-dd/tests/OlapSelector/index.xml
+++ b/cde-pentaho5/solution/pentaho-cdf-dd/tests/OlapSelector/index.xml
@@ -1,0 +1,8 @@
+<index>
+
+  <name>%name</name>
+  <description>%description</description>
+  <visible>true</visible>
+  <display-type>icons</display-type>
+  
+</index>

--- a/cde-pentaho5/solution/pentaho-cdf-dd/tests/OlapSelector/olapSelector.cdfde
+++ b/cde-pentaho5/solution/pentaho-cdf-dd/tests/OlapSelector/olapSelector.cdfde
@@ -1,0 +1,1075 @@
+{
+ "layout": {
+  "title": "CDF - Sample structure",
+  "rows": [
+   {
+    "id": "1a506cb6-b24c-c11b-d9f1-a12864ecde5b",
+    "type": "LayoutResourceFile",
+    "typeDesc": "Resource",
+    "parent": "UnIqEiD",
+    "properties": [
+     {
+      "name": "name",
+      "value": "templateCSS",
+      "type": "Id"
+     },
+     {
+      "name": "resourceFile",
+      "value": "${solution:../../template.css}",
+      "type": "ResourceFile"
+     },
+     {
+      "name": "resourceType",
+      "value": "Css",
+      "type": "Label"
+     }
+    ]
+   },
+   {
+    "id": "9657518a-5535-12d1-2ff3-95525f706312",
+    "type": "LayoutResourceFile",
+    "typeDesc": "Resource",
+    "parent": "UnIqEiD",
+    "properties": [
+     {
+      "name": "name",
+      "value": "referenceCSS",
+      "type": "Id"
+     },
+     {
+      "name": "resourceFile",
+      "value": "${solution:../../cdeReference.css}",
+      "type": "ResourceFile"
+     },
+     {
+      "name": "resourceType",
+      "value": "Css",
+      "type": "Label"
+     }
+    ]
+   },
+   {
+    "id": "f5dbefd4-efe0-46be-c2e0-0a99a94f12e3",
+    "type": "LayoutResourceCode",
+    "typeDesc": "Resource",
+    "parent": "UnIqEiD",
+    "properties": [
+     {
+      "name": "name",
+      "value": "templateAux",
+      "type": "Id"
+     },
+     {
+      "name": "resourceType",
+      "value": "Css",
+      "type": "Label"
+     },
+     {
+      "name": "resourceCode",
+      "value": ".webdetailsPanelContainerCenter {\n    min-height: 1000px;\n}\n ",
+      "type": "Resource"
+     }
+    ]
+   },
+   {
+    "id": "151383e3-f3e3-82c8-49c8-913f96718050",
+    "type": "LayoutRow",
+    "typeDesc": "Row",
+    "parent": "UnIqEiD",
+    "properties": [
+     {
+      "name": "name",
+      "value": "Headers",
+      "type": "Id"
+     },
+     {
+      "name": "height",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "backgroundColor",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "roundCorners",
+      "value": "",
+      "type": "RoundCorners"
+     },
+     {
+      "name": "textAlign",
+      "value": "",
+      "type": "TextAlign"
+     },
+     {
+      "name": "cssClass",
+      "value": "WDheader",
+      "type": "String"
+     }
+    ]
+   },
+   {
+    "id": "e9323c6f-f014-946d-bb3d-067fe35470a3",
+    "type": "LayoutRow",
+    "typeDesc": "Row",
+    "parent": "UnIqEiD",
+    "properties": [
+     {
+      "name": "name",
+      "value": "",
+      "type": "Id"
+     },
+     {
+      "name": "height",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "backgroundColor",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "roundCorners",
+      "value": "",
+      "type": "RoundCorners"
+     },
+     {
+      "name": "textAlign",
+      "value": "",
+      "type": "TextAlign"
+     },
+     {
+      "name": "cssClass",
+      "value": "WDdataCellHeader",
+      "type": "String"
+     }
+    ]
+   },
+   {
+    "id": "b4535e82-0f89-fc43-2eb7-baadc39313bf",
+    "type": "LayoutColumn",
+    "typeDesc": "Column",
+    "parent": "e9323c6f-f014-946d-bb3d-067fe35470a3",
+    "properties": [
+     {
+      "name": "name",
+      "value": "",
+      "type": "Id"
+     },
+     {
+      "name": "columnSpan",
+      "value": "24",
+      "type": "Integer"
+     },
+     {
+      "name": "columnPrepend",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "columnAppend",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "columnPrependTop",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnAppendBottom",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnBorder",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnBigBorder",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "height",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "backgroundColor",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "roundCorners",
+      "value": "",
+      "type": "RoundCorners"
+     },
+     {
+      "name": "textAlign",
+      "value": "",
+      "type": "TextAlign"
+     },
+     {
+      "name": "cssClass",
+      "value": "",
+      "type": "String"
+     }
+    ]
+   },
+   {
+    "id": "4ddb4a60-e415-53b1-0ca9-c25f028654f8",
+    "type": "LayoutHtml",
+    "typeDesc": "Html",
+    "parent": "b4535e82-0f89-fc43-2eb7-baadc39313bf",
+    "properties": [
+     {
+      "name": "name",
+      "value": "",
+      "type": "Id"
+     },
+     {
+      "name": "html",
+      "value": "Olap Selector Component ",
+      "type": "Html"
+     },
+     {
+      "name": "fontSize",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "color",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "cssClass",
+      "value": "",
+      "type": "String"
+     }
+    ]
+   },
+   {
+    "id": "0fb40524-f305-7953-4135-89e9f277068a",
+    "type": "LayoutRow",
+    "typeDesc": "Row",
+    "parent": "UnIqEiD",
+    "properties": [
+     {
+      "name": "name",
+      "value": "Row1",
+      "type": "Id"
+     },
+     {
+      "name": "height",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "backgroundColor",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "roundCorners",
+      "value": "",
+      "type": "RoundCorners"
+     },
+     {
+      "name": "textAlign",
+      "value": "",
+      "type": "TextAlign"
+     },
+     {
+      "name": "cssClass",
+      "value": "WDdataCellBody",
+      "type": "String"
+     }
+    ]
+   },
+   {
+    "id": "5a91cb0a-ce0a-1066-ba19-770b5c0ee47f",
+    "type": "LayoutColumn",
+    "typeDesc": "Column",
+    "parent": "0fb40524-f305-7953-4135-89e9f277068a",
+    "properties": [
+     {
+      "name": "name",
+      "value": "",
+      "type": "Id"
+     },
+     {
+      "name": "columnSpan",
+      "value": "24",
+      "type": "Integer"
+     },
+     {
+      "name": "columnPrepend",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "columnAppend",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "columnPrependTop",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnAppendBottom",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnBorder",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnBigBorder",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "height",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "backgroundColor",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "roundCorners",
+      "value": "",
+      "type": "RoundCorners"
+     },
+     {
+      "name": "textAlign",
+      "value": "",
+      "type": "TextAlign"
+     },
+     {
+      "name": "cssClass",
+      "value": "",
+      "type": "String"
+     }
+    ]
+   },
+   {
+    "id": "f0c1e37a-4a5a-6187-79e2-f7d38dee0e47",
+    "type": "LayoutRow",
+    "typeDesc": "Row",
+    "parent": "5a91cb0a-ce0a-1066-ba19-770b5c0ee47f",
+    "properties": [
+     {
+      "name": "name",
+      "value": "",
+      "type": "Id"
+     },
+     {
+      "name": "height",
+      "value": "30",
+      "type": "Integer"
+     },
+     {
+      "name": "backgroundColor",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "roundCorners",
+      "value": "",
+      "type": "RoundCorners"
+     },
+     {
+      "name": "textAlign",
+      "value": "",
+      "type": "TextAlign"
+     },
+     {
+      "name": "cssClass",
+      "value": "",
+      "type": "String"
+     }
+    ]
+   },
+   {
+    "id": "5cfacbfb-0107-8d87-1170-d2e6b802818f",
+    "type": "LayoutColumn",
+    "typeDesc": "Column",
+    "parent": "f0c1e37a-4a5a-6187-79e2-f7d38dee0e47",
+    "properties": [
+     {
+      "name": "name",
+      "value": "",
+      "type": "Id"
+     },
+     {
+      "name": "columnSpan",
+      "value": "3",
+      "type": "Integer"
+     },
+     {
+      "name": "columnPrepend",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "columnAppend",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "columnPrependTop",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnAppendBottom",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnBorder",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnBigBorder",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "height",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "backgroundColor",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "roundCorners",
+      "value": "",
+      "type": "RoundCorners"
+     },
+     {
+      "name": "textAlign",
+      "value": "",
+      "type": "TextAlign"
+     },
+     {
+      "name": "cssClass",
+      "value": "",
+      "type": "String"
+     }
+    ]
+   },
+   {
+    "id": "c84ead12-c9ab-070c-37c7-555e7a2b4f18",
+    "type": "LayoutHtml",
+    "typeDesc": "Html",
+    "parent": "5cfacbfb-0107-8d87-1170-d2e6b802818f",
+    "properties": [
+     {
+      "name": "name",
+      "value": "label1",
+      "type": "Id"
+     },
+     {
+      "name": "html",
+      "value": "&nbsp;Selected values:&nbsp; ",
+      "type": "Html"
+     },
+     {
+      "name": "fontSize",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "color",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "cssClass",
+      "value": "",
+      "type": "String"
+     }
+    ]
+   },
+   {
+    "id": "658b2fff-04ef-34f1-e7b1-efd3a48c6fea",
+    "type": "LayoutColumn",
+    "typeDesc": "Column",
+    "parent": "f0c1e37a-4a5a-6187-79e2-f7d38dee0e47",
+    "properties": [
+     {
+      "name": "name",
+      "value": "columnLabel",
+      "type": "Id"
+     },
+     {
+      "name": "columnSpan",
+      "value": "21",
+      "type": "Integer"
+     },
+     {
+      "name": "columnPrepend",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "columnAppend",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "columnPrependTop",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnAppendBottom",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnBorder",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnBigBorder",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "height",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "backgroundColor",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "roundCorners",
+      "value": "",
+      "type": "RoundCorners"
+     },
+     {
+      "name": "textAlign",
+      "value": "",
+      "type": "TextAlign"
+     },
+     {
+      "name": "cssClass",
+      "value": "",
+      "type": "String"
+     }
+    ]
+   },
+   {
+    "id": "3baae58d-260f-d4b0-714c-3d1935109c19",
+    "type": "LayoutRow",
+    "typeDesc": "Row",
+    "parent": "5a91cb0a-ce0a-1066-ba19-770b5c0ee47f",
+    "properties": [
+     {
+      "name": "name",
+      "value": "",
+      "type": "Id"
+     },
+     {
+      "name": "height",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "backgroundColor",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "roundCorners",
+      "value": "",
+      "type": "RoundCorners"
+     },
+     {
+      "name": "textAlign",
+      "value": "",
+      "type": "TextAlign"
+     },
+     {
+      "name": "cssClass",
+      "value": "",
+      "type": "String"
+     }
+    ]
+   },
+   {
+    "id": "28dd01be-6663-40ff-762b-c56a541cd9a7",
+    "type": "LayoutColumn",
+    "typeDesc": "Column",
+    "parent": "3baae58d-260f-d4b0-714c-3d1935109c19",
+    "properties": [
+     {
+      "name": "name",
+      "value": "",
+      "type": "Id"
+     },
+     {
+      "name": "columnSpan",
+      "value": "24",
+      "type": "Integer"
+     },
+     {
+      "name": "columnPrepend",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "columnAppend",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "columnPrependTop",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnAppendBottom",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnBorder",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnBigBorder",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "height",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "backgroundColor",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "roundCorners",
+      "value": "",
+      "type": "RoundCorners"
+     },
+     {
+      "name": "textAlign",
+      "value": "",
+      "type": "TextAlign"
+     },
+     {
+      "name": "cssClass",
+      "value": "",
+      "type": "String"
+     }
+    ]
+   },
+   {
+    "id": "08a1f346-99ed-51a1-bfec-432e6bf1d00c",
+    "type": "LayoutHtml",
+    "typeDesc": "Html",
+    "parent": "28dd01be-6663-40ff-762b-c56a541cd9a7",
+    "properties": [
+     {
+      "name": "name",
+      "value": "",
+      "type": "Id"
+     },
+     {
+      "name": "html",
+      "value": "<hr> ",
+      "type": "Html"
+     },
+     {
+      "name": "fontSize",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "color",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "cssClass",
+      "value": "",
+      "type": "String"
+     }
+    ]
+   },
+   {
+    "id": "d9b36765-6cf8-2ecc-6dae-ddfa904e8d72",
+    "type": "LayoutRow",
+    "typeDesc": "Row",
+    "parent": "5a91cb0a-ce0a-1066-ba19-770b5c0ee47f",
+    "properties": [
+     {
+      "name": "name",
+      "value": "",
+      "type": "Id"
+     },
+     {
+      "name": "height",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "backgroundColor",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "roundCorners",
+      "value": "",
+      "type": "RoundCorners"
+     },
+     {
+      "name": "textAlign",
+      "value": "",
+      "type": "TextAlign"
+     },
+     {
+      "name": "cssClass",
+      "value": "",
+      "type": "String"
+     }
+    ]
+   },
+   {
+    "id": "bcaeeb34-bf4f-a783-02fa-a56f78e3f123",
+    "type": "LayoutColumn",
+    "typeDesc": "Column",
+    "parent": "d9b36765-6cf8-2ecc-6dae-ddfa904e8d72",
+    "properties": [
+     {
+      "name": "name",
+      "value": "column1",
+      "type": "Id"
+     },
+     {
+      "name": "columnSpan",
+      "value": "24",
+      "type": "Integer"
+     },
+     {
+      "name": "columnPrepend",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "columnAppend",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "columnPrependTop",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnAppendBottom",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnBorder",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "columnBigBorder",
+      "value": "false",
+      "type": "Boolean"
+     },
+     {
+      "name": "height",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "backgroundColor",
+      "value": "",
+      "type": "Color"
+     },
+     {
+      "name": "roundCorners",
+      "value": "",
+      "type": "RoundCorners"
+     },
+     {
+      "name": "textAlign",
+      "value": "",
+      "type": "TextAlign"
+     },
+     {
+      "name": "cssClass",
+      "value": "",
+      "type": "String"
+     }
+    ]
+   }
+  ]
+ },
+ "components": {
+  "rows": [
+   {
+    "id": "OTHERCOMPONENTS",
+    "name": "Others",
+    "type": "Label",
+    "typeDesc": "<i>Group</i>",
+    "parent": "UnIqEiD",
+    "properties": [
+     {
+      "name": "Group",
+      "value": "Others",
+      "type": "Label"
+     }
+    ]
+   },
+   {
+    "id": "140e9e30-45c7-cd82-ffb6-9742e54eaeba",
+    "type": "ComponentstextComponent",
+    "typeDesc": "Text Component",
+    "parent": "OTHERCOMPONENTS",
+    "properties": [
+     {
+      "name": "name",
+      "value": "textc1",
+      "type": "Id"
+     },
+     {
+      "name": "listeners",
+      "value": "['${p:param1}']",
+      "type": "Listeners"
+     },
+     {
+      "name": "expression",
+      "value": "function f() {\n    if(this.dashboard.getParameterValue('param1')\n        && this.dashboard.getParameterValue('param1').length\n        && this.dashboard.getParameterValue('param1').length > 0) {\n            \n        return JSON.stringify(this.dashboard.getParameterValue('param1')).replace(/(\",\")/g, \"\\\"<br>\\\"\");\n        \n    } else {\n        \n        return \"\"; \n    }\n} ",
+      "type": "JavaScript"
+     },
+     {
+      "name": "priority",
+      "value": 5,
+      "type": "Integer"
+     },
+     {
+      "name": "refreshPeriod",
+      "value": "",
+      "type": "Integer"
+     },
+     {
+      "name": "htmlObject",
+      "value": "${p:columnLabel}",
+      "type": "HtmlObject"
+     },
+     {
+      "name": "executeAtStart",
+      "value": "true",
+      "type": "Boolean"
+     },
+     {
+      "name": "preExecution",
+      "value": "",
+      "type": "JavaScript"
+     },
+     {
+      "name": "postExecution",
+      "value": "",
+      "type": "JavaScript"
+     },
+     {
+      "name": "tooltip",
+      "value": "",
+      "type": "Html"
+     }
+    ]
+   },
+   {
+    "id": "GENERIC",
+    "name": "Generic",
+    "type": "Label",
+    "typeDesc": "<i>Group</i>",
+    "parent": "UnIqEiD",
+    "properties": [
+     {
+      "name": "Group",
+      "value": "Generic",
+      "type": "Label"
+     }
+    ]
+   },
+   {
+    "id": "29980e47-2580-b97b-6f0f-7166609d461b",
+    "type": "ComponentsParameter",
+    "typeDesc": "Simple parameter",
+    "parent": "GENERIC",
+    "properties": [
+     {
+      "name": "name",
+      "value": "param1",
+      "type": "Id"
+     },
+     {
+      "name": "propertyValue",
+      "value": "",
+      "type": "String"
+     },
+     {
+      "name": "parameterViewRole",
+      "value": "unused",
+      "type": "parameterViewRoleCustom"
+     },
+     {
+      "name": "bookmarkable",
+      "value": "false",
+      "type": "Boolean"
+     }
+    ]
+   },
+   {
+    "id": "SELECTORS",
+    "name": "Selects",
+    "type": "Label",
+    "typeDesc": "<i>Group</i>",
+    "parent": "UnIqEiD",
+    "properties": [
+     {
+      "name": "Group",
+      "value": "Selects",
+      "type": "Label"
+     }
+    ]
+   },
+   {
+    "id": "f317b803-d1ea-a2f8-c27f-188f2d6aa203",
+    "type": "ComponentsolapSelector",
+    "typeDesc": "Olap Selector",
+    "parent": "SELECTORS",
+    "properties": [
+     {
+      "name": "name",
+      "value": "olapSel1",
+      "type": "Id"
+     },
+     {
+      "name": "title",
+      "value": "Olap Selector",
+      "type": "String"
+     },
+     {
+      "name": "parameter",
+      "value": "${p:param1}",
+      "type": "Parameter"
+     },
+     {
+      "name": "listeners",
+      "value": "[]",
+      "type": "Listeners"
+     },
+     {
+      "name": "catalog",
+      "value": "mondrian:/SteelWheels",
+      "type": "MondrianCatalog"
+     },
+     {
+      "name": "cube",
+      "value": "SteelWheelsSales",
+      "type": "String"
+     },
+     {
+      "name": "dimensionName",
+      "value": "Customers",
+      "type": "String"
+     },
+     {
+      "name": "parameters",
+      "value": "[]",
+      "type": "ValuesArray"
+     },
+     {
+      "name": "multiSelect",
+      "value": true,
+      "type": "Boolean"
+     },
+     {
+      "name": "priority",
+      "value": 5,
+      "type": "Integer"
+     },
+     {
+      "name": "htmlObject",
+      "value": "${p:column1}",
+      "type": "HtmlObject"
+     },
+     {
+      "name": "executeAtStart",
+      "value": "true",
+      "type": "Boolean"
+     },
+     {
+      "name": "preExecution",
+      "value": "",
+      "type": "JavaScript"
+     },
+     {
+      "name": "postExecution",
+      "value": "",
+      "type": "JavaScript"
+     },
+     {
+      "name": "postFetch",
+      "value": "",
+      "type": "JavaScript"
+     },
+     {
+      "name": "preChange",
+      "value": "",
+      "type": "JavaScript"
+     },
+     {
+      "name": "postChange",
+      "value": "",
+      "type": "JavaScript"
+     },
+     {
+      "name": "tooltip",
+      "value": "",
+      "type": "Html"
+     }
+    ]
+   }
+  ]
+ },
+ "datasources": {
+  "rows": []
+ },
+ "filename": "/public/plugin-samples/pentaho-cdf-dd/tests/OlapSelector/olapSelector.cdfde"
+}

--- a/cde-pentaho5/solution/pentaho-cdf-dd/tests/OlapSelector/olapSelector.wcdf
+++ b/cde-pentaho5/solution/pentaho-cdf-dd/tests/OlapSelector/olapSelector.wcdf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cdf>
+  <title>olapSelector</title>
+  <description>New Selector Component sample</description>
+  <author></author>
+  <widget>false</widget>
+  <widgetName></widgetName>
+  <widgetParameters></widgetParameters>
+  <style>WDDocs</style>
+  <rendererType>blueprint</rendererType>
+</cdf>


### PR DESCRIPTION
	- Replaced split(".") with appropriate regular expression
	- Added sample
	- Fixed minor bug when trying to parse to JSON a parameter containing an empty string