### PR TITLE
Revert [CDE-273] CDE folder structure creation in not being triggered at...

### DIFF
--- a/cde-pentaho-base/src/pt/webdetails/cdf/dd/CdeLifeCycleListener.java
+++ b/cde-pentaho-base/src/pt/webdetails/cdf/dd/CdeLifeCycleListener.java
@@ -42,7 +42,22 @@ public class CdeLifeCycleListener extends SimpleLifeCycleListener {
   @Override
   public void loaded() throws PluginLifecycleException {
     super.loaded();
-    CdeEngine.getInstance().ensureBasicDirs();
+    //CdeEngine.getInstance().ensureBasicDirs();
+
+    /**
+    * IMPORTANT: ensureBasicDirs() functionality was working in 5.0.1 but stopped working in 5.1.0;
+    *
+    * This is because in 5.1.0 's pentaho-solutions/system/systemListeners.xml
+    * bean SecuritySystemListener (responsible for booting up AuthenticationProvider)
+    * is being declared AFTER pluginSystemListener.
+    *
+    * Therefore, if by any chance a plugin desires to access the repository ON STARTUP using a login such as
+    * SecurityHelper.getInstance().runAsSystem(), it will be faced with a InvalidLoginCredentials exception
+    *
+    * Dev/Testing solution:
+    *
+    * in pentaho-solutions/system/systemListeners.xml place bean SecuritySystemListener BEFORE pluginSystemListener
+    */
   }
 
 


### PR DESCRIPTION
... startup, but only upon first CDE Environment instantiation

	- CDE-273 and BISERVER-11865 are linked together; reverting this one in accordance to the BISERVER-11865 revert