### PR TITLE
[BISERVER-11865, BACKLOG-1940] Modifying the lifecycle listener to imple...

### DIFF
--- a/cde-pentaho-base/src/pt/webdetails/cdf/dd/CdeLifeCycleListener.java
+++ b/cde-pentaho-base/src/pt/webdetails/cdf/dd/CdeLifeCycleListener.java
@@ -12,25 +12,14 @@
 */
 package pt.webdetails.cdf.dd;
 
-//import java.io.IOException;
-
-import java.io.IOException;
-import java.io.InputStream;
-
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.engine.IPlatformReadyListener;
 import org.pentaho.platform.api.engine.PluginLifecycleException;
-//import org.pentaho.platform.repository.hibernate.HibernateUtil;
-
-import pt.webdetails.cdf.dd.util.CdeEnvironment;
 import pt.webdetails.cpf.PluginEnvironment;
 import pt.webdetails.cpf.SimpleLifeCycleListener;
-import pt.webdetails.cpf.Util;
-import pt.webdetails.cpf.repository.api.IRWAccess;
-import pt.webdetails.cpf.repository.api.IReadAccess;
 
-public class CdeLifeCycleListener extends SimpleLifeCycleListener {
+public class CdeLifeCycleListener extends SimpleLifeCycleListener implements IPlatformReadyListener {
 
   static Log logger = LogFactory.getLog( CdeLifeCycleListener.class );
 
@@ -42,25 +31,12 @@ public class CdeLifeCycleListener extends SimpleLifeCycleListener {
   @Override
   public void loaded() throws PluginLifecycleException {
     super.loaded();
-    //CdeEngine.getInstance().ensureBasicDirs();
-
-    /**
-    * IMPORTANT: ensureBasicDirs() functionality was working in 5.0.1 but stopped working in 5.1.0;
-    *
-    * This is because in 5.1.0 's pentaho-solutions/system/systemListeners.xml
-    * bean SecuritySystemListener (responsible for booting up AuthenticationProvider)
-    * is being declared AFTER pluginSystemListener.
-    *
-    * Therefore, if by any chance a plugin desires to access the repository ON STARTUP using a login such as
-    * SecurityHelper.getInstance().runAsSystem(), it will be faced with a InvalidLoginCredentials exception
-    *
-    * Dev/Testing solution:
-    *
-    * in pentaho-solutions/system/systemListeners.xml place bean SecuritySystemListener BEFORE pluginSystemListener
-    */
   }
 
-
+  @Override public void ready() throws PluginLifecycleException {
+    logger.debug( "Ready Event for CDE" );
+    CdeEngine.getInstance().ensureBasicDirs();
+  }
 
   @Override
   public void unLoaded() throws PluginLifecycleException {


### PR DESCRIPTION
...ment the transitional IPlatformReadyListener which notifies the listener when the system is fully running. This is the safest point at which to create folders and files in the repository. This modificaiton avoids changing the systemListeners