### PR TITLE
[CDE-371] - Investigate how can we request a dashboard using require

### DIFF
--- a/cde-core/resource/js/cdf-dd-tablemanager.js
+++ b/cde-core/resource/js/cdf-dd-tablemanager.js
@@ -1163,8 +1163,8 @@ var IdRenderer = StringRenderer.extend({
   },
 
   validate: function(value) {
-
-    if(cdfdd.dashboardWcdf.widget) {
+    // the special wrapper ${h:id} (e.g. ${h:column1}) can be used by widgets in legacy dashboards, and by new AMD dashboards.
+    if(cdfdd.dashboardWcdf.widget || cdfdd.dashboardWcdf.require) {
       if(!value.match(/^[\${}:a-zA-Z0-9_.]*$/)) {
         $.prompt('Argument ' + value + ' invalid. Can only contain alphanumeric characters, the special _ and . characters and the {p:name} construct.', {prefix: "popup"});
         return false;

--- a/cde-core/src/pt/webdetails/cdf/dd/CdeConstants.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/CdeConstants.java
@@ -52,6 +52,7 @@ public class CdeConstants {
     public static final String STYLE = "style";
     public static final String SCHEME = "scheme";
     public static final String SUPPORTS = "supports";
+    public static final String ALIAS = "alias";
     /**
      * JSON structure
      */

--- a/cde-core/src/pt/webdetails/cdf/dd/DashboardManager.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/DashboardManager.java
@@ -16,6 +16,7 @@ package pt.webdetails.cdf.dd;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -629,5 +630,133 @@ public class DashboardManager {
       this._dashboardsByCdfdeFilePath.put( cdeFullPath, newDash );
       return newDash;
     }
+  }
+
+  public CdfRunJsDashboardWriteResult getDashboardModule(
+      String wcdfFilePath, CdfRunJsDashboardWriteOptions options,
+      boolean bypassCacheRead, String style, String alias )
+    throws ThingWriteException, UnsupportedEncodingException {
+    if ( wcdfFilePath == null ) {
+      throw new IllegalArgumentException( "wcdfFilePath" );
+    }
+
+    // Figure out what dashboard we should be handling: load its wcdf descriptor.
+    DashboardWcdfDescriptor wcdf;
+    if ( !wcdfFilePath.isEmpty() && wcdfFilePath.endsWith( ".wcdf" ) ) {
+      try {
+        wcdf = DashboardWcdfDescriptor.load( wcdfFilePath );
+      } catch ( IOException ex ) {
+        // TODO: User has no permission to WCDF falls here?
+        throw new ThingWriteException( "While accessing the WCDF file.", ex );
+      }
+
+      if ( wcdf == null ) {
+        // Doesn't exist
+        // TODO: Explain or fix, why create a (totally) empty one?
+        wcdf = new DashboardWcdfDescriptor();
+      }
+    } else {
+      // We didn't receive a valid path. We're in preview mode.
+      // TODO: Support mobile preview mode (must remove dependency on setStyle())
+      wcdf = getPreviewWcdf( wcdfFilePath );
+      bypassCacheRead = true; // no cache for preview
+    }
+
+    if ( StringUtils.isNotEmpty( style ) ) {
+      wcdf.setStyle( style );
+    }
+
+    return this.getDashboardModule( wcdf, options, bypassCacheRead, alias );
+  }
+
+  public CdfRunJsDashboardWriteResult getDashboardModule(
+      DashboardWcdfDescriptor wcdf,
+      CdfRunJsDashboardWriteOptions options,
+      boolean bypassCacheRead, String alias )
+    throws ThingWriteException, UnsupportedEncodingException {
+    // 1. Build the cache key.
+    String cdeFilePath = Utils.sanitizeSlashesInPath( wcdf.getStructurePath() );
+
+    DashboardCacheKey cacheKey = new DashboardCacheKey(
+        cdeFilePath,
+        getPluginResourceLocationManager().getStyleResourceLocation( wcdf.getStyle() ),
+        options.isDebug(),
+        options.isAbsolute(),
+        options.getSchemedRoot(),
+        options.getAliasPrefix() );
+
+    // 2. Check existence and permissions to the original CDFDE file
+    // NOTE: the cache is shared by all users.
+    // The current user may not have access to a cache item previously
+    // created by another user.
+    if ( !Utils.getSystemOrUserReadAccess( wcdf.getPath() ).fileExists( cdeFilePath ) ) {
+      throw new ThingWriteException( new FileNotFoundException( cdeFilePath ) );
+    }
+
+    // 3. Reading from the cache?
+    CdfRunJsDashboardWriteResult dashWrite;
+    if ( !bypassCacheRead ) {
+      try {
+        dashWrite = getDashboardWriteResultFromCache( cacheKey, cdeFilePath );
+      } catch ( FileNotFoundException ex ) {
+        // Is in cache but:
+        // * file doesn't exist (anymore)
+        // * user has insufficient permissions to access the cdfde file
+        throw new ThingWriteException( ex );
+      }
+
+      if ( dashWrite != null ) {
+        // Return cached write result
+        return dashWrite;
+      }
+
+      // Not in cache or cache item expired/invalidated
+    } else {
+      _logger.info( "Bypassing dashboard render cache, rendering." );
+    }
+
+    // 4. Get the Dashboard object
+    Dashboard dash;
+    try {
+      dash = this.getDashboard( wcdf, cdeFilePath, bypassCacheRead );
+    } catch ( ThingReadException ex ) {
+      throw new ThingWriteException( ex );
+    }
+
+    // 5. Obtain a Writer for the CdfRunJs format
+    dashWrite = this.writeDashboardModule( dash, options, bypassCacheRead, alias );
+
+    // 6. Cache the dashboard write
+    return this.replaceDashboardWriteResultInCache( cacheKey, dashWrite );
+  }
+
+  /**
+   * @param dash
+   * @param options
+   * @param bypassCacheRead
+   * @return
+   * @throws ThingWriteException
+   */
+  private CdfRunJsDashboardWriteResult writeDashboardModule(
+      Dashboard dash, CdfRunJsDashboardWriteOptions options,
+      boolean bypassCacheRead, String alias )
+    throws ThingWriteException, UnsupportedEncodingException {
+
+    // 1. Obtain a Writer for the CdfRunJs format
+    CdfRunJsThingWriterFactory factory =
+        new pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.amd.CdfRunJsThingWriterFactory();
+
+    CdfRunJsDashboardWriter writer = factory.getDashboardWriter( dash );
+
+    // 2. Write it
+    CdfRunJsDashboardWriteContext writeContext = CdeEngine.getInstance().getEnvironment()
+        .getCdfRunJsDashboardWriteContext( factory, /*indent*/"", bypassCacheRead, dash, options );
+
+    CdfRunJsDashboardWriteResult.Builder dashboardWriteBuilder =
+        new CdfRunJsDashboardWriteResult.Builder();
+
+    writer.writeModule( dashboardWriteBuilder, writeContext, dash, alias );
+
+    return dashboardWriteBuilder.build();
   }
 }

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsExpressionParameterComponentWriter.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsExpressionParameterComponentWriter.java
@@ -26,9 +26,12 @@ public class CdfRunJsExpressionParameterComponentWriter extends CdfRunJsParamete
     String value = sanitizeExpression( comp.tryGetPropertyValue( "javaScript", "" ) );
     Boolean isBookmarkable = "true".equalsIgnoreCase( comp.tryGetPropertyValue( "bookmarkable", null ) );
 
-    addSetParameterAssignment( out, name, value );
+    // when writing a dashboard as a javascript AMD module, use "this" instead of the "dashboard" object
+    final String targetDash = context.getOptions().isAmdModule() ? "this" : "dashboard";
+
+    addSetParameterAssignment( out, name, value, targetDash );
     if ( isBookmarkable ) {
-      addBookmarkable( out, name );
+      addBookmarkable( out, name, targetDash );
     }
   }
 

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsGenericComponentWriter.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsGenericComponentWriter.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2014 Webdetails, a Pentaho company.  All rights reserved.
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company.  All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -55,11 +55,14 @@ public class CdfRunJsGenericComponentWriter extends JsWriterAbstract implements 
 
     String id = context.getId( comp );
 
+    // when writing a dashboard as an AMD module, we want to refer to "this" instead of "dashboard"
+    final String targetDash = context.getOptions().isAmdModule() ? "this" : "dashboard";
+
     out.append( "var " )
         .append( id )
         .append( " = new " )
         .append( className )
-        .append( "(dashboard, {" )
+        .append( "(" ).append( targetDash ).append( ", {" )
         .append( NEWLINE );
 
     addJsProperty( out, "type", JsonUtils.toJsString( className ), INDENT1, true );

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsParameterComponentWriter.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsParameterComponentWriter.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2014 Webdetails, a Pentaho company.  All rights reserved.
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company.  All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -32,37 +32,43 @@ public class CdfRunJsParameterComponentWriter extends JsWriterAbstract implement
     String name = JsonUtils.toJsString( context.getId( comp ) );
     String value = JsonUtils.toJsString( comp.tryGetPropertyValue( "propertyValue", "" ) );
     String viewRole = JsonUtils.toJsString( comp.tryGetPropertyValue( "parameterViewRole", "unused" ) );
-    Boolean isBookmarkable = "true".equalsIgnoreCase( comp.tryGetPropertyValue( "bookmarkable", null ) );
+    Boolean isBookmarkable = Boolean.valueOf( comp.tryGetPropertyValue( "bookmarkable", null ) );
 
-    addSetParameterAssignment( out, name, value );
+    // when writing a dashboard as an AMD module, we want to refer to "this" instead of "dashboard"
+    final String targetDash = context.getOptions().isAmdModule() ? "this" : "dashboard";
+
+    addSetParameterAssignment( out, name, value, targetDash );
     if ( isBookmarkable ) {
-      addBookmarkable( out, name );
+      addBookmarkable( out, name, targetDash );
     }
-    addViewMode( out, name, viewRole );
+    addViewMode( out, name, viewRole, targetDash );
   }
 
-  protected static void addSetParameterAssignment( StringBuilder out, String name, String value ) {
-    out.append( "dashboard.addParameter(" );
-    out.append( name );
-    out.append( ", " );
-    out.append( value );
-    out.append( ");" );
-    out.append( NEWLINE );
+  protected static void addSetParameterAssignment( StringBuilder out, String name, String value, String targetDash ) {
+    out.append( targetDash )
+        .append( ".addParameter(" )
+        .append( name )
+        .append( ", " )
+        .append( value )
+        .append( ");" )
+        .append( NEWLINE );
   }
 
-  protected static void addViewMode( StringBuilder out, String name, String viewRole ) {
-    out.append( "dashboard.setParameterViewMode(" );
-    out.append( name );
-    out.append( ", " );
-    out.append( viewRole );
-    out.append( ");" );
-    out.append( NEWLINE );
+  protected static void addViewMode( StringBuilder out, String name, String viewRole, String targetDash ) {
+    out.append( targetDash )
+        .append( ".setParameterViewMode(" )
+        .append( name )
+        .append( ", " )
+        .append( viewRole )
+        .append( ");" )
+        .append( NEWLINE );
   }
 
-  protected static void addBookmarkable( StringBuilder out, String name ) {
-    out.append( "dashboard.setBookmarkable(" );
-    out.append( name );
-    out.append( ");" );
-    out.append( NEWLINE );
+  protected static void addBookmarkable( StringBuilder out, String name, String targetDash ) {
+    out.append( targetDash )
+        .append( ".setBookmarkable(" )
+        .append( name )
+        .append( ");" )
+        .append( NEWLINE );
   }
 }

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/CdfRunJsDashboardWriteContext.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/CdfRunJsDashboardWriteContext.java
@@ -63,11 +63,11 @@ public abstract class CdfRunJsDashboardWriteContext extends DefaultThingWriteCon
   protected final CdfRunJsDashboardWriteOptions _options;
 
   public CdfRunJsDashboardWriteContext(
-    IThingWriterFactory factory,
-    String indent,
-    boolean bypassCacheRead,
-    Dashboard dash, // Current Dashboard/Widget
-    CdfRunJsDashboardWriteOptions options ) {
+      IThingWriterFactory factory,
+      String indent,
+      boolean bypassCacheRead,
+      Dashboard dash, // Current Dashboard/Widget
+      CdfRunJsDashboardWriteOptions options ) {
     super( factory, true );
 
     if ( dash == null ) {
@@ -85,8 +85,8 @@ public abstract class CdfRunJsDashboardWriteContext extends DefaultThingWriteCon
   }
 
   protected CdfRunJsDashboardWriteContext(
-    CdfRunJsDashboardWriteContext other,
-    String indent ) {
+      CdfRunJsDashboardWriteContext other,
+      String indent ) {
     super( other.getFactory(), other.getBreakOnError() );
 
     this._indent = StringUtils.defaultIfEmpty( indent, "" );
@@ -159,5 +159,27 @@ public abstract class CdfRunJsDashboardWriteContext extends DefaultThingWriteCon
       .replaceAll( SHORT_P_TAG, aliasAndName )
       .replaceAll( LONG_H_TAG, aliasAndName )
       .replaceAll( LONG_P_TAG, aliasAndName );
+  }
+
+  // Special treatment for generating unique html element ids, according to the value of alias
+  public String replaceAliasH( String content, String alias ) {
+    if ( content == null ) {
+      return "";
+    }
+
+    String _alias = ( StringUtils.isNotEmpty( alias ) ? ( alias + "_" ) : "" );
+
+    String aliasPrefixAndName = ( StringUtils.isNotEmpty( this._options.getAliasPrefix() )
+        ? this._options.getAliasPrefix() + "_$1" : "$1" );
+
+    _alias = _alias + aliasPrefixAndName;
+
+    return content
+      .replaceAll( SHORT_H_TAG, _alias )
+      .replaceAll( LONG_H_TAG, _alias )
+      .replaceAll( SHORT_C_TAG, COMPONENT_PREFIX + aliasPrefixAndName )
+      .replaceAll( LONG_C_TAG, COMPONENT_PREFIX + aliasPrefixAndName )
+      .replaceAll( SHORT_P_TAG, aliasPrefixAndName )
+      .replaceAll( LONG_P_TAG, aliasPrefixAndName );
   }
 }

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/CdfRunJsDashboardWriteOptions.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/CdfRunJsDashboardWriteOptions.java
@@ -1,86 +1,98 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/*!
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company.  All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
 
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard;
 
 import java.io.Serializable;
 import org.apache.commons.lang.StringUtils;
 
-/**
- * @author dcleao
- */
-public class CdfRunJsDashboardWriteOptions implements Serializable
-{
+public class CdfRunJsDashboardWriteOptions implements Serializable {
   private static final long serialVersionUID = 1L;
-  
-  private final boolean _absolute, _debug;
+
+  private final boolean _absolute, _debug, _amdModule;
   private final String  _absRoot, _scheme, _aliasPrefix;
-  
+
   public CdfRunJsDashboardWriteOptions(
-          boolean absolute, 
-          boolean debug,
-          String absRoot, 
-          String scheme)
-  {
-    this("", absolute, debug, absRoot, scheme);
+      boolean absolute,
+      boolean debug,
+      String absRoot,
+      String scheme ) {
+    this( "", false, absolute, debug, absRoot, scheme );
   }
-  
+
   public CdfRunJsDashboardWriteOptions(
-          String  aliasPrefix,
-          boolean absolute, 
-          boolean debug,
-          String absRoot, 
-          String scheme)
-  {
+      boolean amdModule,
+      boolean absolute,
+      boolean debug,
+      String absRoot,
+      String scheme ) {
+    this( "", amdModule, absolute, debug, absRoot, scheme );
+  }
+
+  public CdfRunJsDashboardWriteOptions(
+      String  aliasPrefix,
+      boolean amdModule,
+      boolean absolute,
+      boolean debug,
+      String absRoot,
+      String scheme ) {
     this._aliasPrefix = aliasPrefix;
+    this._amdModule   = amdModule;
     this._absolute    = absolute;
     this._debug       = debug;
     this._absRoot     = absRoot;
     this._scheme      = scheme;
   }
-  
-  public CdfRunJsDashboardWriteOptions addAliasPrefix(String aliasPrefix)
-  {
-    if(StringUtils.isEmpty(aliasPrefix)) { throw new IllegalArgumentException("aliasPrefix"); }
-    
+
+  public CdfRunJsDashboardWriteOptions addAliasPrefix( String aliasPrefix ) {
+    if ( StringUtils.isEmpty( aliasPrefix ) ) {
+      throw new IllegalArgumentException( "aliasPrefix" );
+    }
+
     return new CdfRunJsDashboardWriteOptions(
-      StringUtils.isEmpty(this._aliasPrefix) ? 
-        aliasPrefix : 
-        (this._aliasPrefix + "_" + aliasPrefix),
-      _absolute, 
-      _debug, 
-      _absRoot, 
-      _scheme);
+        StringUtils.isEmpty( this._aliasPrefix ) ? aliasPrefix : ( this._aliasPrefix + "_" + aliasPrefix ),
+        _amdModule,
+        _absolute,
+        _debug,
+        _absRoot,
+        _scheme );
   }
-          
-  public String getAliasPrefix()
-  {
+
+  public String getAliasPrefix() {
     return this._aliasPrefix;
   }
 
-  public String getAbsRoot()
-  {
+  public String getAbsRoot() {
     return this._absRoot;
   }
 
-  public String getSchemedRoot()
-  {
-    return (StringUtils.isEmpty(this._scheme) ? "" : (this._scheme + "://")) + this._absRoot;
+  public String getSchemedRoot() {
+    return ( StringUtils.isEmpty( this._scheme ) ? "" : ( this._scheme + "://" ) ) + this._absRoot;
   }
-  
-  public String getScheme()
-  {
+
+  public String getScheme() {
     return this._scheme;
   }
 
-  public boolean isAbsolute()
-  {
+  public boolean isAbsolute() {
     return this._absolute;
   }
 
-  public boolean isDebug()
-  {
+  public boolean isDebug() {
     return this._debug;
+  }
+
+  public boolean isAmdModule() {
+    return this._amdModule;
   }
 }

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/legacy/CdfRunJsDashboardWriter.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/legacy/CdfRunJsDashboardWriter.java
@@ -5,6 +5,7 @@
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.legacy;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.text.MessageFormat;
 import java.util.regex.Matcher;
 
@@ -15,11 +16,18 @@ import org.apache.commons.logging.LogFactory;
 
 import pt.webdetails.cdf.dd.CdeConstants;
 import pt.webdetails.cdf.dd.CdeEngine;
-import pt.webdetails.cdf.dd.model.core.*;
-import pt.webdetails.cdf.dd.model.core.writer.*;
-import pt.webdetails.cdf.dd.model.core.writer.js.*;
-import pt.webdetails.cdf.dd.model.inst.*;
 
+import pt.webdetails.cdf.dd.model.core.Thing;
+import pt.webdetails.cdf.dd.model.core.UnsupportedThingException;
+import pt.webdetails.cdf.dd.model.core.writer.IThingWriteContext;
+import pt.webdetails.cdf.dd.model.core.writer.IThingWriter;
+import pt.webdetails.cdf.dd.model.core.writer.IThingWriterFactory;
+import pt.webdetails.cdf.dd.model.core.writer.ThingWriteException;
+import pt.webdetails.cdf.dd.model.core.writer.js.JsWriterAbstract;
+import pt.webdetails.cdf.dd.model.inst.Component;
+import pt.webdetails.cdf.dd.model.inst.Dashboard;
+import pt.webdetails.cdf.dd.model.inst.VisualComponent;
+import pt.webdetails.cdf.dd.model.inst.WidgetComponent;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteContext;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteOptions;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteResult;
@@ -55,6 +63,7 @@ public class CdfRunJsDashboardWriter extends JsWriterAbstract implements IThingW
       try {
         return readStyleTemplate( styleName );
       } catch ( IOException ex ) {
+        logger.debug( ex.getMessage() );
       }
     }
 
@@ -89,8 +98,8 @@ public class CdfRunJsDashboardWriter extends JsWriterAbstract implements IThingW
 
   public void write( Object output, IThingWriteContext context, Thing t ) throws ThingWriteException {
     this.write( (CdfRunJsDashboardWriteResult.Builder) output,
-      (CdfRunJsDashboardWriteContext) context,
-      (Dashboard) t );
+        (CdfRunJsDashboardWriteContext) context,
+        (Dashboard) t );
   }
 
   public DashboardWcdfDescriptor.DashboardRendererType getType() {
@@ -249,10 +258,10 @@ public class CdfRunJsDashboardWriter extends JsWriterAbstract implements IThingW
 
     // Get CDE headers
     final String baseUrl = ( options.isAbsolute()
-      ? ( !StringUtils.isEmpty( options.getAbsRoot() )
-      ? options.getSchemedRoot() + "/"
-      : CdeEngine.getInstance().getEnvironment().getUrlProvider().getWebappContextRoot() )
-      : "" );
+        ? ( !StringUtils.isEmpty( options.getAbsRoot() )
+          ? options.getSchemedRoot() + "/"
+          : CdeEngine.getInstance().getEnvironment().getUrlProvider().getWebappContextRoot() )
+        : "" );
 
     StringFilter cssFilter = new StringFilter() {
       public String filter( String input ) {
@@ -297,5 +306,19 @@ public class CdfRunJsDashboardWriter extends JsWriterAbstract implements IThingW
     out.append( EPILOGUE );
 
     return out.toString();
+  }
+
+  // while amd extends legacy this needs to be here and be overriden by the amd writer class
+  public void writeModule( Object output, IThingWriteContext context, Thing t, String alias )
+    throws ThingWriteException, UnsupportedEncodingException {
+    return;
+  }
+
+  // while amd extends legacy this needs to be here and be overriden by the amd writer class
+  public void writeModule( CdfRunJsDashboardWriteResult.Builder builder, CdfRunJsDashboardWriteContext ctx,
+                           Dashboard dash, String alias )
+    throws ThingWriteException, UnsupportedEncodingException {
+
+    return;
   }
 }

--- a/cde-core/src/pt/webdetails/cdf/dd/render/RenderLayout.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/render/RenderLayout.java
@@ -1,6 +1,15 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/*!
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company.  All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
 
 package pt.webdetails.cdf.dd.render;
 
@@ -10,6 +19,7 @@ import java.util.Map;
 
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.Pointer;
+import org.apache.commons.lang.StringUtils;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteContext;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteResult;
 import pt.webdetails.cdf.dd.render.layout.Render;
@@ -37,9 +47,21 @@ public class RenderLayout extends Renderer {
 
       StringBuffer layout = new StringBuffer( );
 
-      layout.append( NEWLINE ).append( getIndent( 2 ) ).append( "<div class='container'>" );
-      renderRows( doc, layoutRows, getWidgets( alias ), alias, layout, 4 );
-      layout.append( NEWLINE ).append( getIndent( 2 ) ).append( "</div>" );
+      if ( getContext().getDashboard().getWcdf().isRequire() ) {
+
+        layout.append( NEWLINE ).append( getIndent( 2 ) ).append( "<div class='" )
+          .append( StringUtils.isEmpty( alias ) ? "container'>" : alias + "_container'>" );
+        // setting indent to -1 prevents NEWLINE and indentation to be appended to layout
+        renderRows( doc, layoutRows, null, alias, layout, -1 );
+        layout.append( NEWLINE ).append( getIndent( 2 ) ).append( "</div>" );
+
+      } else {
+
+        layout.append( NEWLINE ).append( getIndent( 2 ) ).append( "<div class='container'>" );
+        renderRows( doc, layoutRows, getWidgets( alias ), alias, layout, 4 );
+        layout.append( NEWLINE ).append( getIndent( 2 ) ).append( "</div>" );
+
+      }
 
       return layout.toString();
     } catch ( RenderException ex ) {
@@ -60,19 +82,34 @@ public class RenderLayout extends Renderer {
       final Render renderer = (Render) getRender( context );
       renderer.processProperties();
       renderer.aliasId( alias );
-      layout.append( NEWLINE ).append( getIndent( indent ) );
-      layout.append( renderer.renderStart() );
-
-      if ( widgetsByContainerId.containsKey( rowName ) ) {
-        CdfRunJsDashboardWriteResult widgetResult = widgetsByContainerId.get( rowName );
-        layout.append( widgetResult.getLayout() );
+      // when rendering rows for the layout of a dashboard AMD module, skip NEWLINE and indentation
+      if ( indent > -1 ) {
+        layout
+          .append( NEWLINE )
+          .append( getIndent( indent ) )
+          .append( renderer.renderStart() );
+        if ( widgetsByContainerId != null && widgetsByContainerId.containsKey( rowName ) ) {
+          CdfRunJsDashboardWriteResult widgetResult = widgetsByContainerId.get( rowName );
+          layout.append( widgetResult.getLayout() );
+        } else {
+          renderRows( context, context.iteratePointers( MessageFormat.format( XPATH_FILTER, rowId, "" ) ),
+              widgetsByContainerId, alias, layout, indent + 2 );
+        }
+        layout
+          .append( NEWLINE )
+          .append( getIndent( indent ) )
+          .append( renderer.renderClose() );
       } else {
-        renderRows( context, context.iteratePointers( MessageFormat.format( XPATH_FILTER, rowId, "" ) ),
-          widgetsByContainerId, alias, layout, indent + 2 );
+        layout.append( renderer.renderStart() );
+        if ( widgetsByContainerId != null && widgetsByContainerId.containsKey( rowName ) ) {
+          CdfRunJsDashboardWriteResult widgetResult = widgetsByContainerId.get( rowName );
+          layout.append( widgetResult.getLayout() );
+        } else {
+          renderRows( context, context.iteratePointers( MessageFormat.format( XPATH_FILTER, rowId, "" ) ),
+              widgetsByContainerId, alias, layout, -1 );
+        }
+        layout.append( renderer.renderClose() );
       }
-
-      layout.append( NEWLINE ).append( getIndent( indent ) );
-      layout.append( renderer.renderClose() );
     }
   }
 

--- a/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsGenericComponentWriterTest.java
+++ b/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsGenericComponentWriterTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mockito;
 import pt.webdetails.cdf.dd.model.core.writer.ThingWriteException;
 import pt.webdetails.cdf.dd.model.inst.GenericComponent;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteContext;
+import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteOptions;
 import pt.webdetails.cdf.dd.model.meta.*;
 
 import static org.mockito.Mockito.when;
@@ -33,6 +34,7 @@ public class CdfRunJsGenericComponentWriterTest extends TestCase {
 
   private static CdfRunJsGenericComponentWriter genericComponentWriter;
   private static CdfRunJsDashboardWriteContext context;
+  private static CdfRunJsDashboardWriteOptions options;
   private static GenericComponent genericComponent;
   private static GenericComponentType genericComponentType;
 
@@ -40,6 +42,7 @@ public class CdfRunJsGenericComponentWriterTest extends TestCase {
   public void setUp() throws Exception {
     genericComponentWriter = new CdfRunJsGenericComponentWriter();
     context = Mockito.mock( CdfRunJsDashboardWriteContext.class );
+    options = Mockito.mock( CdfRunJsDashboardWriteOptions.class );
     genericComponent = Mockito.mock( GenericComponent.class );
     genericComponentType = Mockito.mock( GenericComponentType.class );
   }
@@ -48,6 +51,7 @@ public class CdfRunJsGenericComponentWriterTest extends TestCase {
   public void tearDown() throws Exception {
     genericComponentWriter = null;
     context = null;
+    options = null;
     genericComponent = null;
     genericComponentType = null;
   }
@@ -59,6 +63,9 @@ public class CdfRunJsGenericComponentWriterTest extends TestCase {
 
     when( genericComponent.getMeta() ).thenReturn( genericComponentType );
     when( context.getId( genericComponent ) ).thenReturn( "test" );
+
+    when( options.getAliasPrefix() ).thenReturn( "" );
+    when( context.getOptions() ).thenReturn( options );
 
     try {
 

--- a/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsParameterComponentWriterTest.java
+++ b/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsParameterComponentWriterTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mockito;
 import pt.webdetails.cdf.dd.model.core.writer.ThingWriteException;
 import pt.webdetails.cdf.dd.model.inst.ParameterComponent;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteContext;
+import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteOptions;
 
 import static org.mockito.Mockito.when;
 
@@ -32,12 +33,14 @@ public class CdfRunJsParameterComponentWriterTest extends TestCase {
 
   private static CdfRunJsParameterComponentWriter parameterComponentWriter;
   private static CdfRunJsDashboardWriteContext context;
+  private static CdfRunJsDashboardWriteOptions options;
   private static ParameterComponent parameterComponent;
 
   @Before
   public void setUp() throws Exception {
     parameterComponentWriter = new CdfRunJsParameterComponentWriter();
     context = Mockito.mock( CdfRunJsDashboardWriteContext.class );
+    options = Mockito.mock( CdfRunJsDashboardWriteOptions.class );
     parameterComponent = Mockito.mock( ParameterComponent.class );
   }
 
@@ -45,6 +48,7 @@ public class CdfRunJsParameterComponentWriterTest extends TestCase {
   public void tearDown() throws Exception {
     parameterComponentWriter = null;
     context = null;
+    options = null;
     parameterComponent = null;
   }
 
@@ -56,6 +60,9 @@ public class CdfRunJsParameterComponentWriterTest extends TestCase {
     when( parameterComponent.tryGetPropertyValue( "bookmarkable", null ) ).thenReturn( "true" );
 
     when( context.getId( parameterComponent ) ).thenReturn( "param1" );
+
+    when( options.getAliasPrefix() ).thenReturn( "" );
+    when( context.getOptions() ).thenReturn( options );
 
     StringBuilder out = new StringBuilder();
 

--- a/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriterTest.java
+++ b/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriterTest.java
@@ -88,11 +88,19 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
 
     List<String> componentClassNames = Arrays.asList(
       "Dashboard",
+      "Logger",
+      "$",
+      "_",
+      "moment",
       "TestComponent1",
       "TestComponent2",
       "TestComponent3" );
     List<String> cdfRequirePaths = Arrays.asList(
       "cdf/Dashboard.Blueprint",
+      "cdf/Logger",
+      "cdf/lib/jquery",
+      "amd!cdf/lib/underscore",
+      "cdf/lib/moment",
       "cdf/components/TestComponent1",
       "cdf/components/TestComponent2",
       "cdf/components/TestComponent3" );
@@ -130,12 +138,20 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
 
     componentClassNames = Arrays.asList(
       "Dashboard",
+      "Logger",
+      "$",
+      "_",
+      "moment",
       "TestComponent1",
       "TestComponent2",
       "TestComponent3",
       "TestResource1");
     cdfRequirePaths = Arrays.asList(
       "cdf/Dashboard.Blueprint",
+      "cdf/Logger",
+      "cdf/lib/jquery",
+      "amd!cdf/lib/underscore",
+      "cdf/lib/moment",
       "cdf/components/TestComponent1",
       "cdf/components/TestComponent2",
       "cdf/components/TestComponent3",
@@ -160,13 +176,13 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
   public void testDashboardType() {
     dashboardWriter =
       new CdfRunJsDashboardWriter( DashboardWcdfDescriptor.DashboardRendererType.BLUEPRINT, false );
-    assertEquals( dashboardWriter.getDashboardRequireModule(), "cdf/Dashboard.Blueprint");
+    assertEquals( dashboardWriter.getDashboardRequireModuleId(), "cdf/Dashboard.Blueprint");
     dashboardWriter =
       new CdfRunJsDashboardWriter( DashboardWcdfDescriptor.DashboardRendererType.BOOTSTRAP, false );
-    assertEquals( dashboardWriter.getDashboardRequireModule(), "cdf/Dashboard.Bootstrap");
+    assertEquals( dashboardWriter.getDashboardRequireModuleId(), "cdf/Dashboard.Bootstrap");
     dashboardWriter =
       new CdfRunJsDashboardWriter( DashboardWcdfDescriptor.DashboardRendererType.MOBILE, false );
-    assertEquals( dashboardWriter.getDashboardRequireModule(), "cdf/Dashboard.Mobile");
+    assertEquals( dashboardWriter.getDashboardRequireModuleId(), "cdf/Dashboard.Mobile");
   }
   
   @Test

--- a/cde-pentaho5/solution/pentaho-cdf-dd/pentaho-cdf-dd-require/dashboard/dashboard_module.xcdf
+++ b/cde-pentaho5/solution/pentaho-cdf-dd/pentaho-cdf-dd-require/dashboard/dashboard_module.xcdf
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cdf>
+  <title>DashboardModule</title>
+  <author>Webdetails</author>
+  <description>Dashboard AMD Module sample</description>
+  <icon></icon>
+  <template>template.html</template>
+  <style>require</style>
+  <require>true</require>
+</cdf>

--- a/cde-pentaho5/solution/pentaho-cdf-dd/pentaho-cdf-dd-require/dashboard/index.properties
+++ b/cde-pentaho5/solution/pentaho-cdf-dd/pentaho-cdf-dd-require/dashboard/index.properties
@@ -1,0 +1,13 @@
+# Copyright 2002 - 2015 Webdetails, a Pentaho company.  All rights reserved.
+#
+# This software was developed by Webdetails and is provided under the terms
+# of the Mozilla Public License, Version 2.0, or any later version. You may not use
+# this file except in compliance with the license. If you need a copy of the license,
+# please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+#
+# Software distributed under the Mozilla Public License is distributed on an "AS IS"
+# basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+# the license for the specific language governing your rights and limitations.
+
+description=Dashboard module sample
+name=Dashboard Module

--- a/cde-pentaho5/solution/pentaho-cdf-dd/pentaho-cdf-dd-require/dashboard/index.xml
+++ b/cde-pentaho5/solution/pentaho-cdf-dd/pentaho-cdf-dd-require/dashboard/index.xml
@@ -1,0 +1,8 @@
+<index>
+
+  <name>%name</name>
+  <description>%description</description>
+  <visible>true</visible>
+  <display-type>icons</display-type>
+  
+</index>

--- a/cde-pentaho5/solution/pentaho-cdf-dd/pentaho-cdf-dd-require/dashboard/template.html
+++ b/cde-pentaho5/solution/pentaho-cdf-dd/pentaho-cdf-dd-require/dashboard/template.html
@@ -1,0 +1,19 @@
+<div class="container">
+<div class="span-24">
+  <h1>Dashboard Module Sample</h1></div>
+
+  <p>Require dashboards as AMD modules using RequireJS.</p>
+  <div id="content1" class="content"></div>
+
+</div>
+
+<script language="javascript" type="text/javascript">
+  require([
+    '/pentaho/plugin/pentaho-cdf-dd/api/renderer/getDashboard?path=%2Fpublic%2Fplugin-samples%2Fpentaho-cdf-dd%2Fpentaho-cdf-dd-require%2Ftests%2FRaphael%2Fraphael.wcdf'],
+    function(RaphaelDash) {
+
+    var raphaelDash = new RaphaelDash();
+    raphaelDash.render("content1");
+    raphaelDash.init();
+  });
+</script>


### PR DESCRIPTION
	- added the endpoint getDashboard to retrieve an AMD module of a dashboard
	- allow users to use the special wrapper ${h:} when editing an AMD dashboard
	- added a sample that requests and renders the Raphael sample dashboard using require
	- updated unit tests