### PR TITLE
[CDE-379] - Keep GetHeaders and GetContent for legacy usages

### DIFF
--- a/cde-core/src/pt/webdetails/cdf/dd/model/core/writer/js/JsWriterAbstract.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/core/writer/js/JsWriterAbstract.java
@@ -1,14 +1,20 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/*!
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company.  All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
 
 package pt.webdetails.cdf.dd.model.core.writer.js;
 
 import org.apache.commons.lang.StringUtils;
 
-/**
- * @author dcleao
- */
 public abstract class JsWriterAbstract {
   protected static final String INDENT1 = "  ";
   protected static final String INDENT2 = "    ";
@@ -17,11 +23,14 @@ public abstract class JsWriterAbstract {
   protected static final String INDENT5 = "          ";
   protected static final String INDENT6 = "            ";
 
-  protected static final String TITLE = INDENT1 + "<title>{0}</title>";
-  protected static final String SCRIPT = INDENT1 + "<script language=\"javascript\" type=\"text/javascript\" src=\"{0}\"></script>";
-  protected static final String STYLE = INDENT1 + "<link href=\"{0}\" rel=\"stylesheet\" type=\"text/css\" />";
+  protected static final String NEWLINE = System.getProperty( "line.separator" );
 
-  protected static final String NEWLINE = System.getProperty( "line.separator" ); //TODO: do we really want this?
+  protected static final String TITLE = INDENT1 + "<title>{0}</title>";
+  protected static final String SCRIPT = INDENT1
+      + "<script language=\"javascript\" type=\"text/javascript\" src=\"{0}\"></script>" + NEWLINE;
+  protected static final String STYLE = INDENT1
+      + "<link href=\"{0}\" rel=\"stylesheet\" type=\"text/css\" />" + NEWLINE;
+
 
   protected static void addCommaAndLineSep( StringBuilder out ) {
     out.append( "," );


### PR DESCRIPTION
	- Adding the line feed (LF) character after each script and link tag to improve readability and resemble legacy output