### PR TITLE
[CDE-373] - Review the DashboardWriter to output require dashboards

### DIFF
--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsExpressionParameterComponentWriter.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsExpressionParameterComponentWriter.java
@@ -26,12 +26,9 @@ public class CdfRunJsExpressionParameterComponentWriter extends CdfRunJsParamete
     String value = sanitizeExpression( comp.tryGetPropertyValue( "javaScript", "" ) );
     Boolean isBookmarkable = "true".equalsIgnoreCase( comp.tryGetPropertyValue( "bookmarkable", null ) );
 
-    // when writing a dashboard as a javascript AMD module, use "this" instead of the "dashboard" object
-    final String targetDash = context.getOptions().isAmdModule() ? "this" : "dashboard";
-
-    addSetParameterAssignment( out, name, value, targetDash );
+    addSetParameterAssignment( out, name, value );
     if ( isBookmarkable ) {
-      addBookmarkable( out, name, targetDash );
+      addBookmarkable( out, name );
     }
   }
 

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsGenericComponentWriter.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsGenericComponentWriter.java
@@ -55,14 +55,11 @@ public class CdfRunJsGenericComponentWriter extends JsWriterAbstract implements 
 
     String id = context.getId( comp );
 
-    // when writing a dashboard as an AMD module, we want to refer to "this" instead of "dashboard"
-    final String targetDash = context.getOptions().isAmdModule() ? "this" : "dashboard";
-
     out.append( "var " )
         .append( id )
         .append( " = new " )
         .append( className )
-        .append( "(" ).append( targetDash ).append( ", {" )
+        .append( "(dashboard, {" )
         .append( NEWLINE );
 
     addJsProperty( out, "type", JsonUtils.toJsString( className ), INDENT1, true );

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsParameterComponentWriter.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsParameterComponentWriter.java
@@ -34,19 +34,15 @@ public class CdfRunJsParameterComponentWriter extends JsWriterAbstract implement
     String viewRole = JsonUtils.toJsString( comp.tryGetPropertyValue( "parameterViewRole", "unused" ) );
     Boolean isBookmarkable = Boolean.valueOf( comp.tryGetPropertyValue( "bookmarkable", null ) );
 
-    // when writing a dashboard as an AMD module, we want to refer to "this" instead of "dashboard"
-    final String targetDash = context.getOptions().isAmdModule() ? "this" : "dashboard";
-
-    addSetParameterAssignment( out, name, value, targetDash );
+    addSetParameterAssignment( out, name, value );
     if ( isBookmarkable ) {
-      addBookmarkable( out, name, targetDash );
+      addBookmarkable( out, name );
     }
-    addViewMode( out, name, viewRole, targetDash );
+    addViewMode( out, name, viewRole );
   }
 
-  protected static void addSetParameterAssignment( StringBuilder out, String name, String value, String targetDash ) {
-    out.append( targetDash )
-        .append( ".addParameter(" )
+  protected static void addSetParameterAssignment( StringBuilder out, String name, String value ) {
+    out.append( "dashboard.addParameter(" )
         .append( name )
         .append( ", " )
         .append( value )
@@ -54,9 +50,8 @@ public class CdfRunJsParameterComponentWriter extends JsWriterAbstract implement
         .append( NEWLINE );
   }
 
-  protected static void addViewMode( StringBuilder out, String name, String viewRole, String targetDash ) {
-    out.append( targetDash )
-        .append( ".setParameterViewMode(" )
+  protected static void addViewMode( StringBuilder out, String name, String viewRole ) {
+    out.append( "dashboard.setParameterViewMode(" )
         .append( name )
         .append( ", " )
         .append( viewRole )
@@ -64,9 +59,8 @@ public class CdfRunJsParameterComponentWriter extends JsWriterAbstract implement
         .append( NEWLINE );
   }
 
-  protected static void addBookmarkable( StringBuilder out, String name, String targetDash ) {
-    out.append( targetDash )
-        .append( ".setBookmarkable(" )
+  protected static void addBookmarkable( StringBuilder out, String name ) {
+    out.append( "dashboard.setBookmarkable(" )
         .append( name )
         .append( ");" )
         .append( NEWLINE );

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriter.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriter.java
@@ -73,6 +73,7 @@ public class CdfRunJsDashboardWriter
       + INDENT2 + "this._processComponents(); },";
   private static final String DASHBOARD_MODULE_PROCESS_COMPONENTS =
       INDENT1 + "_processComponents: function() '{'" + NEWLINE
+      + INDENT2 + "var dashboard = this;" + NEWLINE
       + INDENT2 + "{0}" + NEWLINE
       + INDENT1 + "'}'" + NEWLINE;
   private static final String DASHBOARD_MODULE_STOP = INDENT1 + "});";
@@ -202,16 +203,10 @@ public class CdfRunJsDashboardWriter
     componentList.clear();
 
     StringBuilder out = new StringBuilder();
-    final String targetDash;
 
-    if ( context.getOptions().isAmdModule() ) {
-      targetDash = "this";
-    } else {
-      targetDash = "dashboard";
-      // Output WCDF
-      addAssignment( out, "wcdfSettings", wcdf.toJSON().toString( 2 ) );
-      out.append( NEWLINE );
-    }
+    // Output WCDF
+    addAssignment( out, "var wcdfSettings", wcdf.toJSON().toString( 2 ) );
+    out.append( NEWLINE );
 
     StringBuilder addCompIds = new StringBuilder();
     IThingWriterFactory factory = context.getFactory();
@@ -253,7 +248,7 @@ public class CdfRunJsDashboardWriter
 
     if ( componentList.size() > 0 ) {
       out.append( NEWLINE )
-        .append( targetDash ).append( ".addComponents([" )
+        .append( "dashboard.addComponents([" )
         .append( addCompIds )
         .append( "]);" ).append( NEWLINE );
     }

--- a/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsGenericComponentWriterTest.java
+++ b/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsGenericComponentWriterTest.java
@@ -83,28 +83,6 @@ public class CdfRunJsGenericComponentWriterTest extends TestCase {
 
     Assert.assertEquals( out.toString(), expectedReturnValue.toString() );
 
-
-    // when writing components for dashboard AMD modules, refer to this instead of dashboard
-    when( options.isAmdModule() ).thenReturn( true );
-
-    out.setLength( 0 );
-
-    try {
-
-      genericComponentWriter.write( out, context, genericComponent, "TestComponent" );
-
-    } catch ( ThingWriteException e ) {
-      e.printStackTrace();
-    }
-
-    expectedReturnValue.setLength( 0 );
-    expectedReturnValue.append( "var test = new TestComponent(this, {" ).append( NEWLINE )
-      .append( INDENT ).append( "type: \"TestComponent\"," ).append( NEWLINE )
-      .append( INDENT ).append( "name: \"test\"" ).append( NEWLINE )
-      .append( "});" ).append( NEWLINE );
-
-    Assert.assertEquals( out.toString(), expectedReturnValue.toString() );
-
   }
 
 }

--- a/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsParameterComponentWriterTest.java
+++ b/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsParameterComponentWriterTest.java
@@ -82,26 +82,6 @@ public class CdfRunJsParameterComponentWriterTest extends TestCase {
 
     Assert.assertEquals( out.toString(), dashboardResult.toString() );
 
-    // when writing parameters for dashboard AMD modules, refer to this instead of dashboard
-    when( options.isAmdModule() ).thenReturn( true );
-
-    out.setLength( 0 );
-
-    try {
-
-      parameterComponentWriter.write( out, context, parameterComponent );
-
-    } catch ( ThingWriteException e ) {
-      e.printStackTrace();
-    }
-
-    dashboardResult.setLength( 0 );
-    dashboardResult.append( "this.addParameter(\"param1\", \"1\");" ).append( NEWLINE )
-      .append( "this.setBookmarkable(\"param1\");" ).append( NEWLINE )
-      .append( "this.setParameterViewMode(\"param1\", \"unused\");" ).append( NEWLINE );
-
-    Assert.assertEquals( out.toString(), dashboardResult.toString() );
-
   }
 
 }

--- a/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriterTest.java
+++ b/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriterTest.java
@@ -71,6 +71,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     + INDENT2 + "this._processComponents(); },";
   private static final String DASHBOARD_MODULE_PROCESS_COMPONENTS =
     INDENT1 + "_processComponents: function() '{'" + NEWLINE
+      + INDENT2 + "var dashboard = this;" + NEWLINE
       + INDENT2 + "{0}" + NEWLINE
       + INDENT1 + "'}'" + NEWLINE;
   private static final String DASHBOARD_MODULE_STOP = INDENT1 + "});";
@@ -390,18 +391,9 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     doReturn( componentList ).when( dash ).getRegulars();
 
     Assert.assertEquals(
-      "wcdfSettings = {};" + NEWLINE + NEWLINE + NEWLINE
+      "var wcdfSettings = {};" + NEWLINE + NEWLINE + NEWLINE
         + "dashboard.addComponents([comp1, comp2, comp3]);" + NEWLINE,
       dashboardWriterSpy.writeComponents( context, dash ));
-
-    Assert.assertEquals( 3, dashboardWriter.getComponentList().size() );
-
-    // when writing parameters for dashboard AMD modules, refer to this instead of dashboard
-    when( options.isAmdModule() ).thenReturn( true );
-
-    Assert.assertEquals(
-      NEWLINE + "this.addComponents([comp1, comp2, comp3]);" + NEWLINE,
-      dashboardWriterSpy.writeComponents( context, dash ) );
 
     Assert.assertEquals( 3, dashboardWriter.getComponentList().size() );
 


### PR DESCRIPTION
	- Added "dashboard" local var to be used to reference the current AMD dashboard module inside its "_processComponents" function
	- Added "wcdfSettings" local var to the "_processComponents" function of each AMD dashboard module
	- Updated unit tests accordingly