### PR TITLE
[CLEANUP]

### DIFF
--- a/cde-core/config/karma.ci.conf.js
+++ b/cde-core/config/karma.ci.conf.js
@@ -85,6 +85,9 @@ module.exports = function(config) {
     // enable / disable watching file and executing tests whenever any file changes
     autoWatch: false,
 
+    // The configuration setting tells Karma how long to wait (in milliseconds) after any changes have occurred before starting the test process again.
+    //autoWatchBatchDelay: 250,
+
     // Start these browsers, currently available:
     // - Chrome
     // - ChromeCanary
@@ -98,7 +101,11 @@ module.exports = function(config) {
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,
 
-    //browserNoActivityTimeout: 20000,
+    // to avoid DISCONNECTED messages
+    // see https://github.com/karma-runner/karma/issues/598
+    browserDisconnectTimeout : 10000, // default 2000
+    browserDisconnectTolerance : 1, // default 0
+    browserNoActivityTimeout : 60000, //default 10000
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit

--- a/cde-core/config/karma.ci.conf.legacy.js
+++ b/cde-core/config/karma.ci.conf.legacy.js
@@ -95,6 +95,9 @@ module.exports = function(config) {
     // enable / disable watching file and executing tests whenever any file changes
     autoWatch: false,
 
+    // The configuration setting tells Karma how long to wait (in milliseconds) after any changes have occurred before starting the test process again.
+    //autoWatchBatchDelay: 250,
+
     // Start these browsers, currently available:
     // - Chrome
     // - ChromeCanary
@@ -108,7 +111,11 @@ module.exports = function(config) {
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,
     
-    //browserNoActivityTimeout: 20000,
+    // to avoid DISCONNECTED messages
+    // see https://github.com/karma-runner/karma/issues/598
+    browserDisconnectTimeout : 10000, // default 2000
+    browserDisconnectTolerance : 1, // default 0
+    browserNoActivityTimeout : 60000, //default 10000
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit

--- a/cde-core/config/karma.conf.js
+++ b/cde-core/config/karma.conf.js
@@ -85,6 +85,9 @@ module.exports = function(config) {
     // enable / disable watching file and executing tests whenever any file changes
     autoWatch: true,
 
+    // The configuration setting tells Karma how long to wait (in milliseconds) after any changes have occurred before starting the test process again.
+    autoWatchBatchDelay: 250,
+
     // Start these browsers, currently available:
     // - Chrome
     // - ChromeCanary
@@ -98,7 +101,7 @@ module.exports = function(config) {
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,
 
-    //browserNoActivityTimeout: 20000,
+    browserNoActivityTimeout: 600000,
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit

--- a/cde-core/config/karma.conf.legacy.js
+++ b/cde-core/config/karma.conf.legacy.js
@@ -95,6 +95,9 @@ module.exports = function(config) {
     // enable / disable watching file and executing tests whenever any file changes
     autoWatch: true,
 
+    // The configuration setting tells Karma how long to wait (in milliseconds) after any changes have occurred before starting the test process again.
+    autoWatchBatchDelay: 250,
+
     // Start these browsers, currently available:
     // - Chrome
     // - ChromeCanary
@@ -108,7 +111,7 @@ module.exports = function(config) {
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,
 
-    //browserNoActivityTimeout: 20000,
+    browserNoActivityTimeout: 600000,
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit


### PR DESCRIPTION
	- Avoid DISCONNECTED messages while running tests using PhantomJS, for core tests also