### PR TITLE
[CDE-544] Saving a CDE dashboard with filename I-[~!@#$%^&*(){}|.,]-=…

### DIFF
--- a/cde-core/resource/js/cdf-dd.js
+++ b/cde-core/resource/js/cdf-dd.js
@@ -795,9 +795,11 @@ var CDFDD = Base.extend({
       return;
     }
 
-    var fullPath = CDFDDFileName.split("/");
+    var separator = CDFDDFileName.indexOf( '%2F' ) != -1 ? '%2F' /* separator in a uri encoded path */ : '/' /*  default non encoded path */ ;
+
+    var fullPath = CDFDDFileName.split( separator );
     var solution = fullPath[1];
-    var path = fullPath.slice(2, fullPath.length - 1).join("/");
+    var path = fullPath.slice(2, fullPath.length - 1).join( separator );
     var file = fullPath[fullPath.length - 1].replace(".cdfde", "_tmp.wcdf");
 
     this.logger.info("Saving temporary dashboard...");

--- a/cde-core/src/pt/webdetails/cdf/dd/editor/DashboardEditor.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/editor/DashboardEditor.java
@@ -15,6 +15,7 @@ package pt.webdetails.cdf.dd.editor;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URLEncoder;
 import java.util.HashMap;
 
 import org.apache.commons.lang.StringUtils;
@@ -31,6 +32,7 @@ import pt.webdetails.cdf.dd.util.CdeEnvironment;
 import pt.webdetails.cpf.Util;
 import pt.webdetails.cpf.context.api.IUrlProvider;
 import pt.webdetails.cpf.repository.api.IReadAccess;
+import pt.webdetails.cpf.utils.CharsetHelper;
 
 public class DashboardEditor {
 
@@ -95,7 +97,8 @@ public class DashboardEditor {
     } catch ( Exception e ) {
       logger.fatal( "Unable to get CDF dependencies", e );
     }
-    tokens.put( CdeConstants.FILE_NAME_TAG, DashboardWcdfDescriptor.toStructurePath( wcdfPath ) );
+    tokens.put( CdeConstants.FILE_NAME_TAG,
+        URLEncoder.encode( DashboardWcdfDescriptor.toStructurePath( wcdfPath ), CharsetHelper.getEncoding() ) );
 
     IUrlProvider urlProvider = CdeEngine.getEnv().getPluginEnv().getUrlProvider();
     final String apiPath = urlProvider.getPluginBaseUrl();

--- a/cde-pentaho5/resource/js/cdf-dd-base.js
+++ b/cde-pentaho5/resource/js/cdf-dd-base.js
@@ -507,7 +507,7 @@ var SaveRequests = {
           }
           var solutionPath = selectedFolder.split("/");
           myself.initStyles(function() {
-            window.location = window.location.protocol + "//" + window.location.host + wd.cde.endpoints.getWebappBasePath() + '/api/repos/:' + selectedFolder.replace(new RegExp("/", "g"), ":") + selectedFile + '/edit';
+            window.location = window.location.protocol + "//" + window.location.host + wd.cde.endpoints.getWebappBasePath() + '/api/repos/:' + selectedFolder.replace(new RegExp("/", "g"), ":") +  encodeURIComponent( selectedFile ) + '/edit';
           });
         } else {
           throw result && result.result;

--- a/cde-pentaho5/src/pt/webdetails/cdf/dd/api/SyncronizerApi.java
+++ b/cde-pentaho5/src/pt/webdetails/cdf/dd/api/SyncronizerApi.java
@@ -15,6 +15,7 @@ package pt.webdetails.cdf.dd.api;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.List;
 
@@ -47,6 +48,7 @@ import pt.webdetails.cdf.dd.util.CdeEnvironment;
 import pt.webdetails.cdf.dd.util.JsonUtils;
 import pt.webdetails.cdf.dd.util.Utils;
 import pt.webdetails.cpf.repository.api.IReadAccess;
+import pt.webdetails.cpf.utils.CharsetHelper;
 import pt.webdetails.cpf.utils.MimeTypes;
 
 @Path( "pentaho-cdf-dd/api/syncronizer" )
@@ -91,6 +93,12 @@ public class SyncronizerApi { //TODO: synchronizer?
     boolean isPreview = false;
 
     if ( !file.isEmpty() && !file.equals( UNSAVED_FILE_PATH ) ) {
+
+      try {
+        file = URLDecoder.decode( file, CharsetHelper.getEncoding() );
+      } catch ( Exception e ){
+        /* do nothing */
+      }
 
       // check access to path folder
       String fileDir =
@@ -236,6 +244,12 @@ public class SyncronizerApi { //TODO: synchronizer?
     boolean isPreview = false;
 
     if ( !file.isEmpty() && !file.equals( UNSAVED_FILE_PATH ) ) {
+
+      try {
+        file = URLDecoder.decode( file, CharsetHelper.getEncoding() );
+      } catch ( Exception e ){
+        /* do nothing */
+      }
 
       if ( StringUtils.isEmpty( title ) ) {
         title = FilenameUtils.getBaseName( file );


### PR DESCRIPTION
…_+|;'"?<>~` and a normal title fails with 404 Page not found

	- filepath in URL now gets wrapped in encodeUriComponent
	- server-side attempts a URLDecoder.decode() of the provided filepaths
	- server-side replacement of cdf-dd.html's @FILENAME@ token now wraps the wcdfPath in a URLEncoder.encode()