### PR TITLE
[CDF-531][CDE-527][CDE-528][CDE-529]

### DIFF
--- a/cde-core/resource/js/cdf-dd-layout.js
+++ b/cde-core/resource/js/cdf-dd-layout.js
@@ -702,11 +702,11 @@ var LayoutAddBootstrapPanelOperation = AddRowOperation.extend({
 
   models: [LayoutBootstrapPanelModel.MODEL],
   canMoveInto: [
-    LayoutRowModel.MODEL, LayoutColumnModel.MODEL, LayoutBootstrapColumnModel.MODEL, LayoutFreeFormModel.MODEL,
+    LayoutColumnModel.MODEL, LayoutBootstrapColumnModel.MODEL, LayoutFreeFormModel.MODEL,
     LayoutBootstrapPanelHeaderModel.MODEL, LayoutBootstrapPanelBodyModel.MODEL, LayoutBootstrapPanelFooterModel.MODEL
   ],
   canMoveTo: [
-    LayoutSpaceModel.MODEL, LayoutHtmlModel.MODEL, LayoutImageModel.MODEL,
+    LayoutRowModel.MODEL, LayoutSpaceModel.MODEL, LayoutHtmlModel.MODEL, LayoutImageModel.MODEL,
     LayoutBootstrapPanelModel.MODEL
   ],
 
@@ -852,11 +852,11 @@ var LayoutAddFreeFormOperation = AddRowOperation.extend({
 
   models: [LayoutFreeFormModel.MODEL],
   canMoveInto: [
-    LayoutRowModel.MODEL, LayoutColumnModel.MODEL, LayoutBootstrapColumnModel.MODEL, LayoutFreeFormModel.MODEL,
+    LayoutColumnModel.MODEL, LayoutBootstrapColumnModel.MODEL, LayoutFreeFormModel.MODEL,
     LayoutBootstrapPanelHeaderModel.MODEL, LayoutBootstrapPanelBodyModel.MODEL, LayoutBootstrapPanelFooterModel.MODEL
   ],
   canMoveTo: [
-    LayoutSpaceModel.MODEL, LayoutHtmlModel.MODEL, LayoutImageModel.MODEL,
+    LayoutRowModel.MODEL, LayoutSpaceModel.MODEL, LayoutHtmlModel.MODEL, LayoutImageModel.MODEL,
     LayoutBootstrapPanelModel.MODEL
   ],
 
@@ -940,7 +940,7 @@ var LayoutAddSpaceOperation = AddRowOperation.extend({
 
   id: "LAYOUT_ADD_SPACE",
   types: [
-    LayoutRowModel.MODEL
+    LayoutRowModel.MODEL, LayoutColumnModel.MODEL, LayoutBootstrapColumnModel.MODEL
   ],
   name: "Add Space",
   description: "Adds a horizontal rule",
@@ -969,7 +969,7 @@ var LayoutAddImageOperation = AddRowOperation.extend({
 
   id: "LAYOUT_ADD_IMAGE",
   types: [
-    LayoutRowModel.MODEL, LayoutColumnModel.MODEL, LayoutBootstrapColumnModel.MODEL,
+    LayoutColumnModel.MODEL, LayoutBootstrapColumnModel.MODEL,
     LayoutFreeFormModel.MODEL, LayoutBootstrapPanelHeaderModel.MODEL,
     LayoutBootstrapPanelBodyModel.MODEL, LayoutBootstrapPanelFooterModel.MODEL
   ],
@@ -978,11 +978,11 @@ var LayoutAddImageOperation = AddRowOperation.extend({
 
   models: [LayoutImageModel.MODEL],
   canMoveInto: [
-    LayoutRowModel.MODEL, LayoutColumnModel.MODEL, LayoutBootstrapColumnModel.MODEL, LayoutBootstrapPanelHeaderModel.MODEL,
+    LayoutColumnModel.MODEL, LayoutBootstrapColumnModel.MODEL, LayoutBootstrapPanelHeaderModel.MODEL,
     LayoutBootstrapPanelBodyModel.MODEL, LayoutBootstrapPanelFooterModel.MODEL, LayoutFreeFormModel.MODEL
   ],
   canMoveTo: [
-     LayoutSpaceModel.MODEL, LayoutHtmlModel.MODEL, LayoutImageModel.MODEL, LayoutBootstrapPanelModel.MODEL
+    LayoutRowModel.MODEL, LayoutSpaceModel.MODEL, LayoutHtmlModel.MODEL, LayoutImageModel.MODEL, LayoutBootstrapPanelModel.MODEL
   ],
 
   constructor: function() {
@@ -999,7 +999,7 @@ var LayoutAddHtmlOperation = AddRowOperation.extend({
 
   id: "LAYOUT_ADD_HTML",
   types: [
-    LayoutRowModel.MODEL, LayoutColumnModel.MODEL, LayoutBootstrapColumnModel.MODEL,
+    LayoutColumnModel.MODEL, LayoutBootstrapColumnModel.MODEL,
     LayoutBootstrapPanelHeaderModel.MODEL, LayoutBootstrapPanelBodyModel.MODEL,
     LayoutBootstrapPanelFooterModel.MODEL, LayoutFreeFormModel.MODEL
   ],
@@ -1008,11 +1008,11 @@ var LayoutAddHtmlOperation = AddRowOperation.extend({
 
   models: [LayoutHtmlModel.MODEL],
   canMoveInto: [
-    LayoutRowModel.MODEL, LayoutColumnModel.MODEL, LayoutBootstrapColumnModel.MODEL, LayoutBootstrapPanelHeaderModel.MODEL,
+    LayoutColumnModel.MODEL, LayoutBootstrapColumnModel.MODEL, LayoutBootstrapPanelHeaderModel.MODEL,
     LayoutBootstrapPanelBodyModel.MODEL, LayoutBootstrapPanelFooterModel.MODEL, LayoutFreeFormModel.MODEL
   ],
   canMoveTo: [
-    LayoutSpaceModel.MODEL, LayoutHtmlModel.MODEL, LayoutImageModel.MODEL, LayoutBootstrapPanelModel.MODEL
+    LayoutRowModel.MODEL, LayoutSpaceModel.MODEL, LayoutHtmlModel.MODEL, LayoutImageModel.MODEL, LayoutBootstrapPanelModel.MODEL
   ],
 
   constructor: function() {

--- a/cde-core/resource/js/cdf-dd.js
+++ b/cde-core/resource/js/cdf-dd.js
@@ -102,7 +102,9 @@ var CDFDD = Base.extend({
     // Keyboard shortcuts
     $(function () {
       $(document).keydown(function (e) {
-        if($(e.target).is('input, textarea') || e.ctrlKey) {
+        var target = $(e.target);
+        var hasPopup = (target.find('.popup:visible').length || target.find('.jqmWindow:visible').length) > 0 ;
+        if(target.is('input, select, textarea') || hasPopup || e.ctrlKey) {
           return;
         }
 

--- a/cde-core/resource/resources/cdf-dd.html
+++ b/cde-core/resource/resources/cdf-dd.html
@@ -3,7 +3,6 @@
 <head>
   <!-- Generic stuff --><!-- Framework CSS --><!--[if lt IE 8]><link rel="stylesheet" href="@CDF_RESOURCES_BASE_URL@/js-legacy/lib/blueprint/ie.css" type="text/css" media="screen, projection"><![endif]-->
   <!-- CDF TODO: change paths? move to an include? -->
-  <link rel="stylesheet" href="@CDF_RESOURCES_BASE_URL@/js-legacy/lib/autobox/jquery.ui.autobox.css" type="text/css">
   <link rel="stylesheet" href="@CDF_RESOURCES_BASE_URL@/js-legacy/lib/blueprint/screen.css" type="text/css">
   <link rel="stylesheet" href="@CDF_RESOURCES_BASE_URL@/js-legacy/lib/fancybox/jquery.fancybox.css" type="text/css">
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/cde-core/resource/resources/custom/properties/Bootstrap/property.xml
+++ b/cde-core/resource/resources/custom/properties/Bootstrap/property.xml
@@ -3,7 +3,7 @@
     <Header>
       <Name>bootstrapExtraSmall</Name>
       <Parent>BaseProperty</Parent>
-      <DefaultValue></DefaultValue>
+      <DefaultValue>12</DefaultValue>
       <Description>Extra Small Devices</Description>
       <Tooltip>Bootstrap Extra Small Devices Property</Tooltip>
       <InputType>String</InputType>
@@ -17,7 +17,7 @@
     <Header>
       <Name>bootstrapSmall</Name>
       <Parent>BaseProperty</Parent>
-      <DefaultValue></DefaultValue>
+      <DefaultValue/>
       <Description>Small Devices</Description>
       <Tooltip>Bootstrap Small Devices Property</Tooltip>
       <InputType>String</InputType>
@@ -31,7 +31,7 @@
     <Header>
       <Name>bootstrapMedium</Name>
       <Parent>BaseProperty</Parent>
-      <DefaultValue></DefaultValue>
+      <DefaultValue/>
       <Description>Medium Devices</Description>
       <Tooltip>Bootstrap Medium Devices Property</Tooltip>
       <InputType>String</InputType>
@@ -45,7 +45,7 @@
     <Header>
       <Name>bootstrapLarge</Name>
       <Parent>BaseProperty</Parent>
-      <DefaultValue></DefaultValue>
+      <DefaultValue/>
       <Description>Large Devices</Description>
       <Tooltip>Bootstrap Large Devices Property</Tooltip>
       <InputType>String</InputType>
@@ -59,7 +59,7 @@
     <Header>
       <Name>bootstrapCssClass</Name>
       <Parent>BaseProperty</Parent>
-      <DefaultValue></DefaultValue>
+      <DefaultValue/>
       <Description>Bootstrap Css Class</Description>
       <Tooltip>Bootstrap Css Class to be used when this element is rendered</Tooltip>
       <InputType>String</InputType>

--- a/cde-core/resource/resources/ext-editor.html
+++ b/cde-core/resource/resources/ext-editor.html
@@ -44,8 +44,6 @@
     <!-- CDF files -->
     <script language="javascript" type="text/javascript" src="@CDF_RESOURCES_BASE_URL@/js-legacy/lib/shims.js"></script>
     <script language="javascript" type="text/javascript" src="@CDF_RESOURCES_BASE_URL@/js-legacy/lib/blockUI/jquery.blockUI.js"></script>
-    <script language="javascript" type="text/javascript" src="@CDF_RESOURCES_BASE_URL@/js-legacy/lib/autobox/jquery.ui.autobox.ext.js"></script>
-    <script language="javascript" type="text/javascript" src="@CDF_RESOURCES_BASE_URL@/js-legacy/lib/autobox/jquery.ui.autobox.js"></script>
     <script language="javascript" type="text/javascript" src="@CDF_RESOURCES_BASE_URL@/js-legacy/lib/underscore/underscore.js"></script>  
     <script language="javascript" type="text/javascript" src="@CDF_RESOURCES_BASE_URL@/js-legacy/lib/mustache/mustache.js"></script>  
     <script language="javascript" type="text/javascript" src="@CDF_RESOURCES_BASE_URL@/js-legacy/lib/backbone/backbone.js"></script>    

--- a/cde-core/src/pt/webdetails/cdf/dd/render/layout/BootstrapColumnRender.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/render/layout/BootstrapColumnRender.java
@@ -59,6 +59,8 @@ public class BootstrapColumnRender extends DivRender {
 
     if ( !getPropertyString( "bootstrapExtraSmall" ).equals( "" ) ) {
       css += "col-xs-" + getPropertyString( "bootstrapExtraSmall" );
+    } else {
+      css += "col-xs-12";
     }
     if ( !getPropertyString( "bootstrapSmall" ).equals( "" ) ) {
       css += " col-sm-" + getPropertyString( "bootstrapSmall" );
@@ -75,7 +77,6 @@ public class BootstrapColumnRender extends DivRender {
     if ( lastColumn() ) {
       css += " last";
     }
-
 
     return ( css.equals( "" ) ? css : " class='" + css + "'" );
   }

--- a/cde-core/test-js/legacy/cdf-dd-tablemanager-spec.js
+++ b/cde-core/test-js/legacy/cdf-dd-tablemanager-spec.js
@@ -220,9 +220,7 @@ describe("CDF-DD-TABLEMANAGER-TESTS", function() {
 
     it("canMoveInto", function() {
       var testCanMoveInto = function(dragIds, dropId, expectedResult) {
-        var L = dragIds.length;
-        alert(dropId)
-        for (var i = 0; i < L; i++) {
+        for (var i = 0, L = dragIds.length; i < L; i++) {
           expect(tableManager.canMoveInto(dragIds[i], dropId)).toBe(expectedResult);
         }
       }
@@ -230,8 +228,8 @@ describe("CDF-DD-TABLEMANAGER-TESTS", function() {
       testCanMoveInto(['row', 'html', 'image', 'space', 'freeForm', 'bootstrapPanel'], 'freeForm', true);
       testCanMoveInto(['resource', 'col', 'col-2'], 'freeForm', false);
 
-      testCanMoveInto(['col', 'col-2', 'html', 'image', 'freeForm', 'bootstrapPanel'], 'row', true);
-      testCanMoveInto(['resource', 'row', 'space'], 'row', false);
+      testCanMoveInto(['col', 'col-2'], 'row', true);
+      testCanMoveInto(['html', 'image', 'freeForm', 'bootstrapPanel', 'resource', 'row', 'space'], 'row', false);
 
       testCanMoveInto(['row', 'html', 'image', 'space', 'freeForm', 'bootstrapPanel'], 'col', true);
       testCanMoveInto(['resource', 'col', 'col-2'], 'col', false);
@@ -254,8 +252,8 @@ describe("CDF-DD-TABLEMANAGER-TESTS", function() {
 
       testCanMoveTo(['resource', 'row', 'col', 'col-2', 'html', 'image', 'space', 'freeForm', 'bootstrapPanel'], 'freeForm', false);
 
-      testCanMoveTo(['resource', 'col', 'col-2', 'html', 'image', 'freeForm', 'bootstrapPanel'], 'row', false);
-      testCanMoveTo(['row', 'space'], 'row', true);
+      testCanMoveTo(['resource', 'col', 'col-2'], 'row', false);
+      testCanMoveTo(['row', 'space', 'html', 'image', 'freeForm', 'bootstrapPanel'], 'row', true);
 
       testCanMoveTo(['resource', 'row', 'html', 'image', 'space', 'freeForm', 'bootstrapPanel'], 'col', false);
       testCanMoveTo(['col', 'col-2'], 'col', true);

--- a/cde-core/test-src/pt/webdetails/cdf/dd/render/layout/BootstrapColumnRenderTest.java
+++ b/cde-core/test-src/pt/webdetails/cdf/dd/render/layout/BootstrapColumnRenderTest.java
@@ -18,9 +18,11 @@ import junit.framework.TestCase;
 import org.apache.commons.jxpath.JXPathContext;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import java.util.Iterator;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
 
 public class BootstrapColumnRenderTest extends TestCase {
 
@@ -28,11 +30,16 @@ public class BootstrapColumnRenderTest extends TestCase {
 
   private class BootstrapColumnRenderForTest extends BootstrapColumnRender {
 
-    private String bootstrapCss;
+    private Map<String, String> properties = new HashMap<String, String>();
 
-    public BootstrapColumnRenderForTest( JXPathContext context ) {
+    public BootstrapColumnRenderForTest( JXPathContext context) {
       super( context );
-      this.bootstrapCss = "";
+    }
+
+    @Override
+    protected String getPropertyString( String prop ) {
+      String value = this.properties.get( prop );
+      return value != null ? value : "";
     }
 
     @Override
@@ -40,13 +47,8 @@ public class BootstrapColumnRenderTest extends TestCase {
       return false;
     }
 
-    @Override
-    protected String getBootstrapClassString() {
-      return this.bootstrapCss;
-    }
-
-    private void setBootstrapCss( String css ) {
-      this.bootstrapCss = " class='" + css + "'";
+    private void addProperty( String prop, String value ) {
+      this.properties.put( prop, value );
     }
 
     private void setPropertyBagClass( String css ) {
@@ -56,7 +58,7 @@ public class BootstrapColumnRenderTest extends TestCase {
 
   @Before
   public void setUp() throws Exception {
-    JXPathContext context = Mockito.mock( JXPathContext.class );
+    JXPathContext context = mock( JXPathContext.class );
     renderForTest = new BootstrapColumnRenderForTest( context );
   }
 
@@ -65,14 +67,14 @@ public class BootstrapColumnRenderTest extends TestCase {
     renderForTest.processProperties();
     String div = renderForTest.renderStart();
 
-    Assert.assertEquals( "<div><div >", div );
+    Assert.assertEquals( "<div class='col-xs-12'><div >", div );
 
   }
 
   @Test
   public void testRenderStartWithBootstrapCss() {
 
-    renderForTest.setBootstrapCss( "col-xs-5" );
+    renderForTest.addProperty( "bootstrapExtraSmall", "5" );
     renderForTest.processProperties();
 
     String div = renderForTest.renderStart();
@@ -88,14 +90,14 @@ public class BootstrapColumnRenderTest extends TestCase {
 
     String div = renderForTest.renderStart();
 
-    Assert.assertEquals( "<div><div  class='span-6 ' >", div );
+    Assert.assertEquals( "<div class='col-xs-12'><div  class='span-6 ' >", div );
   }
 
   @Test
   public void testRenderStartWithAll() {
 
     renderForTest.setPropertyBagClass( "span-6" );
-    renderForTest.setBootstrapCss( "col-xs-5" );
+    renderForTest.addProperty( "bootstrapExtraSmall", "5" );
     renderForTest.processProperties();
 
     String div = renderForTest.renderStart();


### PR DESCRIPTION
 - [CDF-531] Removed reference to jquery.ui.autobox from CDE
 - [CDE-527] As a user, I want bootstrap layout elements without an assigned xs span value to fall back to col-xs-12
 - [CDE-528] As a user, I want bootstrap layout rows to only allow bootstrap layout column elements as children
 - [CDE-529] Opening component parameter popup does not block use of arrow keys to navigate properties

@pamval rebase done. please review
