### PR TITLE
[CDE-544] Saving a CDE dashboard with filename I-[~!@#$%^&*(){}|.,]-=…

### DIFF
--- a/cde-core/resource/js/cdf-dd.js
+++ b/cde-core/resource/js/cdf-dd.js
@@ -797,9 +797,11 @@ var CDFDD = Base.extend({
       return;
     }
 
-    var fullPath = CDFDDFileName.split("/");
+    var separator = CDFDDFileName.indexOf( '%2F' ) != -1 ? '%2F' /* separator in a uri encoded path */ : '/' /*  default non encoded path */ ;
+
+    var fullPath = CDFDDFileName.split( separator );
     var solution = fullPath[1];
-    var path = fullPath.slice(2, fullPath.length - 1).join("/");
+    var path = fullPath.slice(2, fullPath.length - 1).join( separator );
     var file = fullPath[fullPath.length - 1].replace(".cdfde", "_tmp.wcdf");
 
     this.logger.info("Saving temporary dashboard...");

--- a/cde-core/src/pt/webdetails/cdf/dd/editor/DashboardEditor.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/editor/DashboardEditor.java
@@ -15,6 +15,7 @@ package pt.webdetails.cdf.dd.editor;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URLEncoder;
 import java.util.HashMap;
 
 import org.apache.commons.lang.StringUtils;
@@ -31,6 +32,7 @@ import pt.webdetails.cdf.dd.util.CdeEnvironment;
 import pt.webdetails.cpf.Util;
 import pt.webdetails.cpf.context.api.IUrlProvider;
 import pt.webdetails.cpf.repository.api.IReadAccess;
+import pt.webdetails.cpf.utils.CharsetHelper;
 
 public class DashboardEditor {
 
@@ -95,7 +97,8 @@ public class DashboardEditor {
     } catch ( Exception e ) {
       logger.fatal( "Unable to get CDF dependencies", e );
     }
-    tokens.put( CdeConstants.FILE_NAME_TAG, DashboardWcdfDescriptor.toStructurePath( wcdfPath ) );
+    tokens.put( CdeConstants.FILE_NAME_TAG,
+        URLEncoder.encode( DashboardWcdfDescriptor.toStructurePath( wcdfPath ), CharsetHelper.getEncoding() ) );
 
     IUrlProvider urlProvider = CdeEngine.getEnv().getPluginEnv().getUrlProvider();
     final String apiPath = urlProvider.getPluginBaseUrl();

--- a/cde-core/src/pt/webdetails/cdf/dd/util/Utils.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/util/Utils.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
 import java.text.DecimalFormat;
 import java.util.List;
 import java.util.logging.Level;
@@ -40,7 +41,7 @@ import pt.webdetails.cpf.repository.api.IBasicFile;
 import pt.webdetails.cpf.repository.api.IContentAccessFactory;
 import pt.webdetails.cpf.repository.api.IRWAccess;
 import pt.webdetails.cpf.repository.api.IReadAccess;
-
+import pt.webdetails.cpf.utils.CharsetHelper;
 
 public class Utils {
 
@@ -388,7 +389,7 @@ public class Utils {
     IReadAccess readAccess = null;
     if ( filePath.startsWith( "/" + CdeEnvironment.getSystemDir() + "/" ) && ( filePath.endsWith( ".wcdf" ) || filePath
         .endsWith( ".cdfde" ) ) ) {
-      readAccess = getSystemReadAccess( filePath.split( "/" )[ 2 ], null );
+      readAccess = getSystemReadAccess( filePath.split( "/" )[2], null );
     } else if ( CdeEnvironment.getUserContentAccess().hasAccess( filePath, FileAccess.EXECUTE ) ) {
       readAccess = CdeEnvironment.getUserContentAccess();
     }
@@ -400,7 +401,7 @@ public class Utils {
     if ( CdeEngine.getEnv().getUserSession().isAdministrator() && (
         filePath.startsWith( "/" + CdeEnvironment.getSystemDir() + "/" ) && ( filePath.endsWith( ".wcdf" ) || filePath
         .endsWith( ".cdfde" ) ) ) ) {
-      rwAccess = getSystemRWAccess( filePath.split( "/" )[ 2 ], null );
+      rwAccess = getSystemRWAccess( filePath.split( "/" )[2], null );
     } else if ( CdeEnvironment.getUserContentAccess().fileExists( filePath ) ) {
 
       if ( CdeEnvironment.getUserContentAccess().hasAccess( filePath, FileAccess.WRITE ) ) {
@@ -459,6 +460,21 @@ public class Utils {
 
   public static ICdeEnvironment getCdeEnvironment() {
     return CdeEngine.getInstance().getEnvironment();
+  }
+
+  public static String getURLDecoded( String s ){
+    return getURLDecoded( s , CharsetHelper.getEncoding() );
+  }
+
+  public static String getURLDecoded( String s, String enc ){
+    if( s != null ){
+      try {
+        return URLDecoder.decode( s, ( enc != null ? enc : CharsetHelper.getEncoding() ) );
+      } catch ( Exception e ){
+        /* do nothing, assume this value as-is */
+      }
+    }
+    return s;
   }
 
 }

--- a/cde-pentaho/resource/js/cdf-dd-base.js
+++ b/cde-pentaho/resource/js/cdf-dd-base.js
@@ -58,7 +58,7 @@ wd.cde.endpoints = {
   },
 
   isEmptyFilePath: function(filePath) {
-    return (!filePath || "/null/null/null" == filePath);
+    return (!filePath || "/null/null/null" == filePath || encodeURIComponent("/null/null/null") == filePath );
   },
 
   getSaikuUiPluginUrl: function() {
@@ -453,7 +453,7 @@ var SaveRequests = {
           var solutionPath = selectedFolder.split("/");
           myself.initStyles(function() {
             //cdfdd.setExitNotification(false);
-            window.location = window.location.protocol + "//" + window.location.host + wd.cde.endpoints.getPluginUrl() + 'Edit?solution=' + solutionPath[0] + "&path=" + solutionPath.slice(1).join("/") + "&file=" + selectedFile;
+            window.location = window.location.protocol + "//" + window.location.host + wd.cde.endpoints.getPluginUrl() + 'Edit?solution=' + solutionPath[0] + "&path=" + solutionPath.slice(1).join("/") + "&file=" + encodeURIComponent( selectedFile );
           });
         } else {
           throw json.result;
@@ -501,7 +501,7 @@ var SaveRequests = {
           wcdf.widget = true;
           myself.saveSettingsRequest(wcdf);
           myself.initStyles(function() {
-            window.location = window.location.protocol + "//" + window.location.host + wd.cde.endpoints.getPluginUrl() + 'Edit?solution=' + solutionPath[0] + "&path=" + solutionPath.slice(1).join("/") + "&file=" + selectedFile;
+            window.location = window.location.protocol + "//" + window.location.host + wd.cde.endpoints.getPluginUrl() + 'Edit?solution=' + solutionPath[0] + "&path=" + solutionPath.slice(1).join("/") + "&file=" + encodeURIComponent( selectedFile );
           });
         } else {
           throw json.result;

--- a/cde-pentaho/src/pt/webdetails/cdf/dd/DashboardDesignerContentGenerator.java
+++ b/cde-pentaho/src/pt/webdetails/cdf/dd/DashboardDesignerContentGenerator.java
@@ -78,6 +78,7 @@ import pt.webdetails.cpf.repository.api.IBasicFile;
 import pt.webdetails.cpf.repository.api.IReadAccess;
 import pt.webdetails.cpf.repository.api.IUserContentAccess;
 import pt.webdetails.cpf.repository.util.RepositoryHelper;
+import pt.webdetails.cpf.utils.CharsetHelper;
 import pt.webdetails.cpf.utils.MimeTypes;
 
 public class DashboardDesignerContentGenerator extends SimpleContentGenerator {
@@ -181,6 +182,7 @@ public class DashboardDesignerContentGenerator extends SimpleContentGenerator {
     String title = null;
     String description = null;
     String operation = null;
+    String file = null;
     String path = null;
     String cdfStructure = null;
     if ( getRequest().getContentType().startsWith( "multipart/form-data" ) ) {
@@ -200,7 +202,7 @@ public class DashboardDesignerContentGenerator extends SimpleContentGenerator {
             operation = fi.getString();
           }
           if ( "file".equals( fi.getFieldName() ) ) {
-            path = fi.getString();
+            path = Utils.getURLDecoded( fi.getString(), CharsetHelper.getEncoding() );
           }
           if ( "cdfstructure".equals( fi.getFieldName() ) ) {
             cdfStructure = fi.getString( "UTF-8" );
@@ -244,6 +246,11 @@ public class DashboardDesignerContentGenerator extends SimpleContentGenerator {
       cdfStructure = (String) getRequestParameters().getStringParameter( REQUEST_PARAM_CDFSTRUCTURE, null );
 
       path = getRequestParameters().getStringParameter( REQUEST_PARAM_FILE, null );
+      file = (String) getRequestParameters().getParameter( "file" );
+
+      path = Utils.getURLDecoded( path, CharsetHelper.getEncoding() );
+      file = Utils.getURLDecoded( file, CharsetHelper.getEncoding() );
+
       title = StringUtils.defaultIfEmpty( ( (String) getRequestParameters().getParameter( REQUEST_PARAM_TITLE ) ),
         FilenameUtils.getBaseName( path ) );
       description =
@@ -263,7 +270,6 @@ public class DashboardDesignerContentGenerator extends SimpleContentGenerator {
       Object result = null;
 
       if ( OPERATION_LOAD.equalsIgnoreCase( operation ) ) {
-        String file = getRequestParameters().getStringParameter( "file", null );
         JsonUtils.buildJsonResult( getResponse().getOutputStream(), true, dashboardStructure.load( file ) );
         return;
       } else if ( OPERATION_DELETE.equalsIgnoreCase( operation ) ) {
@@ -281,7 +287,6 @@ public class DashboardDesignerContentGenerator extends SimpleContentGenerator {
 
       } else if ( OPERATION_SAVE_SETTINGS.equalsIgnoreCase( operation ) ) {
         // check if user is attempting to save settings over a new (non yet saved) dashboard/widget/template
-        String file = getRequestParameters().getStringParameter( "file", null );
         if ( StringUtils.isEmpty( file ) || UNSAVED_FILE_PATH.equals( file ) ) {
           String msg = Messages.getString( "CdfTemplates.ERROR_003_SAVE_DASHBOARD_FIRST" );
           logger.warn( msg );

--- a/cde-pentaho5/resource/js/cdf-dd-base.js
+++ b/cde-pentaho5/resource/js/cdf-dd-base.js
@@ -67,7 +67,7 @@ wd.cde.endpoints = {
   },
 
   isEmptyFilePath: function(filePath) {
-    return (!filePath || "/" == filePath);
+    return (!filePath || "/" == filePath || encodeURIComponent("/") == filePath );
   },
 
   getFilePathFromUrl: function() {
@@ -507,7 +507,7 @@ var SaveRequests = {
           }
           var solutionPath = selectedFolder.split("/");
           myself.initStyles(function() {
-            window.location = window.location.protocol + "//" + window.location.host + wd.cde.endpoints.getWebappBasePath() + '/api/repos/:' + selectedFolder.replace(new RegExp("/", "g"), ":") + selectedFile + '/edit';
+            window.location = window.location.protocol + "//" + window.location.host + wd.cde.endpoints.getWebappBasePath() + '/api/repos/:' + selectedFolder.replace(new RegExp("/", "g"), ":") +  encodeURIComponent( selectedFile ) + '/edit';
           });
         } else {
           throw result && result.result;

--- a/cde-pentaho5/src/pt/webdetails/cdf/dd/api/SyncronizerApi.java
+++ b/cde-pentaho5/src/pt/webdetails/cdf/dd/api/SyncronizerApi.java
@@ -47,6 +47,7 @@ import pt.webdetails.cdf.dd.util.CdeEnvironment;
 import pt.webdetails.cdf.dd.util.JsonUtils;
 import pt.webdetails.cdf.dd.util.Utils;
 import pt.webdetails.cpf.repository.api.IReadAccess;
+import pt.webdetails.cpf.utils.CharsetHelper;
 import pt.webdetails.cpf.utils.MimeTypes;
 
 @Path( "pentaho-cdf-dd/api/syncronizer" )
@@ -91,6 +92,8 @@ public class SyncronizerApi { //TODO: synchronizer?
     boolean isPreview = false;
 
     if ( !file.isEmpty() && !file.equals( UNSAVED_FILE_PATH ) ) {
+
+      file = Utils.getURLDecoded( file, CharsetHelper.getEncoding() );
 
       // check access to path folder
       String fileDir =
@@ -235,7 +238,10 @@ public class SyncronizerApi { //TODO: synchronizer?
 
     boolean isPreview = false;
 
-    if ( !file.isEmpty() && !file.equals( UNSAVED_FILE_PATH ) ) {
+    if ( !file.isEmpty() &&
+        !( file.equals( UNSAVED_FILE_PATH ) || Utils.getURLDecoded( file ).equals( UNSAVED_FILE_PATH ) ) ){
+
+      file = Utils.getURLDecoded( file, CharsetHelper.getEncoding() );
 
       if ( StringUtils.isEmpty( title ) ) {
         title = FilenameUtils.getBaseName( file );


### PR DESCRIPTION
…_+|;'"?<>~` and a normal title fails with 404 Page not found

	- filepath in URL now gets wrapped in encodeUriComponent
	- server-side attempts a URLDecoder.decode() of the provided filepaths
	- server-side replacement of cdf-dd.html's @FILENAME@ token now wraps the wcdfPath in a URLEncoder.encode()