### PR TITLE
[CDE-543] - CSS external resources should be included using the css! requireJS plugin

### DIFF
--- a/cde-core/resource/js/cde-core-require-js-cfg.js
+++ b/cde-core/resource/js/cde-core-require-js-cfg.js
@@ -26,14 +26,18 @@
     prefix = requirePaths['cde/components'] = 'resource/resources/custom/amd-components';
 
   } else if(typeof CONTEXT_PATH !== "undefined") { // production
-    prefix = requirePaths['cde/components'] = CONTEXT_PATH + 'api/repos/pentaho-cdf-dd/resources/custom/'
-      + (isDebug ? '/amd-components' : 'amd-components-compressed');
+    prefix = requirePaths['cde/components'] = CONTEXT_PATH + 'plugin/pentaho-cdf-dd/api/resources/resources/custom/'
+      + (isDebug ? 'amd-components' : 'amd-components-compressed');
     requirePaths['cde/repo/components'] = CONTEXT_PATH + 'plugin/pentaho-cdf-dd/api/resources/public/cde/components';
 
+    requirePaths['cde/resources'] = CONTEXT_PATH + 'plugin/pentaho-cdf-dd/api/resources';
+
   } else if(typeof FULL_QUALIFIED_URL != "undefined") { // embedded
-    prefix = requirePaths['cde/components'] = FULL_QUALIFIED_URL + 'api/repos/pentaho-cdf-dd/resources/custom'
-      + (isDebug ? '/amd-components' : '/amd-components-compressed');
+    prefix = requirePaths['cde/components'] = FULL_QUALIFIED_URL + 'plugin/pentaho-cdf-dd/api/resources/resources/custom'
+      + (isDebug ? 'amd-components' : 'amd-components-compressed');
     requirePaths['cde/repo/components'] = FULL_QUALIFIED_URL + 'plugin/pentaho-cdf-dd/api/resources/public/cde/components';
+
+    requirePaths['cde/resources'] = FULL_QUALIFIED_URL + 'plugin/pentaho-cdf-dd/api/resources';
 
   } else { // build
     prefix = requirePaths['cde/components'] = '../resources/custom/amd-components';

--- a/cde-core/src/pt/webdetails/cdf/dd/CdeConstants.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/CdeConstants.java
@@ -88,4 +88,20 @@ public class CdeConstants {
   public static final String DASHBOARD_ALIAS_TAG = "@ALIAS@";
 
   public static final String CUSTOM_COMPONENT_CONFIG_FILENAME = "component.xml";
+
+  public enum REQUIREJS_PLUGIN {
+    CSS( "css!" ), NONAMD( "amd!" );
+
+    private final String plugin;
+
+    REQUIREJS_PLUGIN( String plugin ) {
+      this.plugin = plugin;
+    }
+
+    public String toString() {
+      return this.plugin;
+    }
+  }
+
+  public static final String RESOURCE_AMD_NAMESPACE = "cde/resources";
 }

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/CdfRunJsDashboardWriteContext.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/CdfRunJsDashboardWriteContext.java
@@ -95,7 +95,7 @@ public abstract class CdfRunJsDashboardWriteContext extends DefaultThingWriteCon
 
   public CdfRunJsDashboardWriteContext withIndent( String indent ) {
     return CdeEngine.getInstance().getEnvironment()
-      .getCdfRunJsDashboardWriteContext( this, indent );
+      .getCdfRunJsDashboardWriteContext( getFactory(), indent, _bypassCacheRead, _dash, _options );
   }
 
   public String getIndent() {
@@ -169,7 +169,7 @@ public abstract class CdfRunJsDashboardWriteContext extends DefaultThingWriteCon
 
     return content
       .replaceAll( SHORT_C_TAG, COMPONENT_PREFIX + "$1" )
-      .replaceAll( LONG_C_TAG, COMPONENT_PREFIX + "$1")
+      .replaceAll( LONG_C_TAG, COMPONENT_PREFIX + "$1" )
       .replaceAll( SHORT_H_TAG, aliasAndName )
       .replaceAll( SHORT_P_TAG, "$1" )
       .replaceAll( LONG_H_TAG, aliasAndName )

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/PentahoCdfRunJsDashboardWriteContext.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/PentahoCdfRunJsDashboardWriteContext.java
@@ -11,16 +11,16 @@
  * the license for the specific language governing your rights and limitations.
  */
 
-package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard;
+package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.amd;
 
-import org.apache.commons.lang.StringUtils;
+import pt.webdetails.cdf.dd.CdeConstants;
 import pt.webdetails.cdf.dd.CdeEngine;
 import pt.webdetails.cdf.dd.model.core.writer.IThingWriterFactory;
 import pt.webdetails.cdf.dd.model.inst.Dashboard;
+import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteContext;
+import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteOptions;
 
 public class PentahoCdfRunJsDashboardWriteContext extends CdfRunJsDashboardWriteContext {
-  private static final String RESOURCE_API_GET = "api/resources";
-  private static final String SYS_RESOURCE_API_GET = "/pentaho/api/repos";
 
   public PentahoCdfRunJsDashboardWriteContext( IThingWriterFactory factory,
                                                String indent, boolean bypassCacheRead, Dashboard dash,
@@ -37,35 +37,18 @@ public class PentahoCdfRunJsDashboardWriteContext extends CdfRunJsDashboardWrite
   public String replaceTokens( String content ) {
     final long timestamp = this._writeDate.getTime();
 
-    final String root = getRoot();
-
     final String path = this._dash.getSourcePath().replaceAll( "(.+/).*", "$1" );
 
     return content
       .replaceAll( DASHBOARD_PATH_TAG, path.replaceAll( "(^/.*/$)", "$1" ) ) // replace the dashboard path token
-      .replaceAll( ABS_IMG_TAG, root + RESOURCE_API_GET + "$1" + "?v="
-        + timestamp ) // build the image links, with a timestamp for caching purposes
-      .replaceAll( REL_IMG_TAG, root + RESOURCE_API_GET + path + "$1" + "?v="
-        + timestamp ) // build the image links, with a timestamp for caching purposes
-      .replaceAll( ABS_DIR_RES_TAG, root + RESOURCE_API_GET + "$2" ) // Directories don't need the caching timestamp
-      .replaceAll( REL_DIR_RES_TAG,
-        root + RESOURCE_API_GET + path + "$2" )// Directories don't need the caching timestamp
-      .replaceAll( ABS_RES_TAG, root + RESOURCE_API_GET + "$2" + "?v="
-        + timestamp )// build the image links, with a timestamp for caching purposes
-      .replaceAll( REL_RES_TAG, root + RESOURCE_API_GET + path + "$2" + "?v="
-        + timestamp ) // build the image links, with a timestamp for caching purposes
-      .replaceAll( ABS_SYS_RES_TAG, root + RESOURCE_API_GET + "/" + getSystemDir() + "/" + getPluginId( path )
-        + "$1" + "?v=" + timestamp ) //build system resources links, with a timestamp for caching purposes
-      .replaceAll( REL_SYS_RES_TAG, root + RESOURCE_API_GET + path
-        + "$1" + "?v=" + timestamp ); //build system resources links, with a timestamp for caching purposes
-  }
-
-  protected String getRoot() {
-    return this._options.isAbsolute() ?
-      ( !StringUtils.isEmpty(this._options.getAbsRoot()) ?
-        ( this._options.getSchemedRoot() + CdeEngine.getInstance().getEnvironment().getApplicationBaseContentUrl() )
-        : CdeEngine.getInstance().getEnvironment().getApplicationBaseContentUrl())
-      : CdeEngine.getInstance().getEnvironment().getApplicationBaseContentUrl();
+      .replaceAll( ABS_IMG_TAG, "$1" + "?v=" + timestamp ) // build the image links, with a timestamp for caching purposes
+      .replaceAll( REL_IMG_TAG, path + "$1" + "?v=" + timestamp ) // build the image links, with a timestamp for caching purposes
+      .replaceAll( ABS_DIR_RES_TAG, "$2" ) // Directories don't need the caching timestamp
+      .replaceAll( REL_DIR_RES_TAG, path + "$2" )// Directories don't need the caching timestamp
+      .replaceAll( ABS_RES_TAG, "$2" + "?v=" + timestamp )// build the image links, with a timestamp for caching purposes
+      .replaceAll( REL_RES_TAG, path + "$2" + "?v=" + timestamp ) // build the image links, with a timestamp for caching purposes
+      .replaceAll( ABS_SYS_RES_TAG, "/" + getSystemDir() + "/" + getPluginId( path ) + "$1" + "?v=" + timestamp ) //build system resources links, with a timestamp for caching purposes
+      .replaceAll( REL_SYS_RES_TAG, path + "$1" + "?v=" + timestamp ); //build system resources links, with a timestamp for caching purposes
   }
 
   protected String getSystemDir() {

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/legacy/PentahoCdfRunJsDashboardWriteContext.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/legacy/PentahoCdfRunJsDashboardWriteContext.java
@@ -1,0 +1,89 @@
+/*!
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+
+package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.legacy;
+
+import org.apache.commons.lang.StringUtils;
+import pt.webdetails.cdf.dd.CdeEngine;
+import pt.webdetails.cdf.dd.model.core.writer.IThingWriterFactory;
+import pt.webdetails.cdf.dd.model.inst.Dashboard;
+import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteContext;
+import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteOptions;
+
+public class PentahoCdfRunJsDashboardWriteContext extends CdfRunJsDashboardWriteContext {
+  private static final String RESOURCE_API_GET = "api/resources";
+  private static final String SYS_RESOURCE_API_GET = "/pentaho/api/repos";
+
+  public PentahoCdfRunJsDashboardWriteContext( IThingWriterFactory factory,
+                                               String indent, boolean bypassCacheRead, Dashboard dash,
+                                               CdfRunJsDashboardWriteOptions options ) {
+    super( factory, indent, bypassCacheRead, dash, options );
+  }
+
+  public PentahoCdfRunJsDashboardWriteContext( CdfRunJsDashboardWriteContext factory,
+                                               String indent ) {
+    super( factory, indent );
+  }
+
+  @Override
+  public String replaceTokens( String content ) {
+    final long timestamp = this._writeDate.getTime();
+
+    final String root = getRoot();
+
+    final String path = this._dash.getSourcePath().replaceAll( "(.+/).*", "$1" );
+
+    return content
+      .replaceAll( DASHBOARD_PATH_TAG, path.replaceAll( "(^/.*/$)", "$1" ) ) // replace the dashboard path token
+      .replaceAll( ABS_IMG_TAG, root + RESOURCE_API_GET + "$1" + "?v="
+        + timestamp ) // build the image links, with a timestamp for caching purposes
+      .replaceAll( REL_IMG_TAG, root + RESOURCE_API_GET + path + "$1" + "?v="
+        + timestamp ) // build the image links, with a timestamp for caching purposes
+      .replaceAll( ABS_DIR_RES_TAG, root + RESOURCE_API_GET + "$2" ) // Directories don't need the caching timestamp
+      .replaceAll( REL_DIR_RES_TAG,
+        root + RESOURCE_API_GET + path + "$2" )// Directories don't need the caching timestamp
+      .replaceAll( ABS_RES_TAG, root + RESOURCE_API_GET + "$2" + "?v="
+        + timestamp )// build the image links, with a timestamp for caching purposes
+      .replaceAll( REL_RES_TAG, root + RESOURCE_API_GET + path + "$2" + "?v="
+        + timestamp ) // build the image links, with a timestamp for caching purposes
+      .replaceAll( ABS_SYS_RES_TAG, root + RESOURCE_API_GET + "/" + getSystemDir() + "/" + getPluginId( path )
+        + "$1" + "?v=" + timestamp ) //build system resources links, with a timestamp for caching purposes
+      .replaceAll( REL_SYS_RES_TAG, root + RESOURCE_API_GET + path
+        + "$1" + "?v=" + timestamp ); //build system resources links, with a timestamp for caching purposes
+  }
+
+  protected String getRoot() {
+    return this._options.isAbsolute()
+      ? ( !StringUtils.isEmpty(this._options.getAbsRoot() )
+        ? ( this._options.getSchemedRoot() + CdeEngine.getInstance().getEnvironment().getApplicationBaseContentUrl() )
+        : CdeEngine.getInstance().getEnvironment().getApplicationBaseContentUrl() )
+      : CdeEngine.getInstance().getEnvironment().getApplicationBaseContentUrl();
+  }
+
+  protected String getSystemDir() {
+    return CdeEngine.getEnv().getSystemDir();
+  }
+
+  protected String getPluginId( String path ) {
+    if ( path.startsWith( "/" ) ) {
+      path = path.replaceFirst( "/", "" );
+    }
+
+    if ( path.startsWith( getSystemDir() ) ) {
+      return path.split( "/" )[ 1 ];
+    } else {
+      return "";
+    }
+  }
+
+}

--- a/cde-pentaho5/src/pt/webdetails/cdf/dd/PentahoCdeEnvironment.java
+++ b/cde-pentaho5/src/pt/webdetails/cdf/dd/PentahoCdeEnvironment.java
@@ -29,7 +29,7 @@ import pt.webdetails.cdf.dd.model.core.writer.IThingWriterFactory;
 import pt.webdetails.cdf.dd.model.inst.Dashboard;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteContext;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteOptions;
-import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.PentahoCdfRunJsDashboardWriteContext;
+import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.legacy.PentahoCdfRunJsDashboardWriteContext;
 import pt.webdetails.cdf.dd.plugin.resource.PluginResourceLocationManager;
 import pt.webdetails.cdf.dd.util.Utils;
 import pt.webdetails.cpf.PentahoPluginEnvironment;
@@ -169,7 +169,12 @@ public class PentahoCdeEnvironment extends PentahoPluginEnvironment implements I
   public CdfRunJsDashboardWriteContext getCdfRunJsDashboardWriteContext( IThingWriterFactory factory, String indent,
                                                                          boolean bypassCacheRead, Dashboard dash,
                                                                          CdfRunJsDashboardWriteOptions options ) {
-    return new PentahoCdfRunJsDashboardWriteContext( factory, indent, bypassCacheRead, dash, options );
+    if( dash.getWcdf().isRequire() ) {
+      return new pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.amd.PentahoCdfRunJsDashboardWriteContext(
+          factory, indent, bypassCacheRead, dash, options );
+    } else {
+      return new PentahoCdfRunJsDashboardWriteContext( factory, indent, bypassCacheRead, dash, options );
+    }
   }
 
   @Override

--- a/cde-pentaho5/test-src/pt/webdetails/cdf/dd/CdeEnvironmentForTests.java
+++ b/cde-pentaho5/test-src/pt/webdetails/cdf/dd/CdeEnvironmentForTests.java
@@ -21,7 +21,7 @@ import pt.webdetails.cdf.dd.model.core.writer.IThingWriterFactory;
 import pt.webdetails.cdf.dd.model.inst.Dashboard;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteContext;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteOptions;
-import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.PentahoCdfRunJsDashboardWriteContext;
+import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.legacy.PentahoCdfRunJsDashboardWriteContext;
 import pt.webdetails.cdf.dd.testUtils.ContentAccessFactoryForTests;
 import pt.webdetails.cpf.PluginEnvironment;
 import pt.webdetails.cpf.context.api.IUrlProvider;

--- a/cde-pentaho5/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/legacy/CdfRunJsParameterComponentWriterTest.java
+++ b/cde-pentaho5/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/legacy/CdfRunJsParameterComponentWriterTest.java
@@ -1,3 +1,16 @@
+/*!
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.components.legacy;
 
 import junit.framework.Assert;
@@ -7,7 +20,7 @@ import org.mockito.Mockito;
 import pt.webdetails.cdf.dd.model.core.writer.IThingWriter;
 import pt.webdetails.cdf.dd.model.core.writer.ThingWriteException;
 import pt.webdetails.cdf.dd.model.inst.ParameterComponent;
-import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.PentahoCdfRunJsDashboardWriteContext;
+import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.legacy.PentahoCdfRunJsDashboardWriteContext;
 
 import static org.mockito.Mockito.when;
 

--- a/cde-pentaho5/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/PentahoCdfRunJsDashboardWriteContextForTesting.java
+++ b/cde-pentaho5/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/PentahoCdfRunJsDashboardWriteContextForTesting.java
@@ -11,27 +11,18 @@
  * the license for the specific language governing your rights and limitations.
  */
 
-package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard;
+package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.amd;
 
-import org.apache.commons.lang.StringUtils;
 import pt.webdetails.cdf.dd.model.core.writer.IThingWriterFactory;
 import pt.webdetails.cdf.dd.model.inst.Dashboard;
+import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteOptions;
 
 public class PentahoCdfRunJsDashboardWriteContextForTesting extends PentahoCdfRunJsDashboardWriteContext {
   public PentahoCdfRunJsDashboardWriteContextForTesting(
-      IThingWriterFactory factory,
-      String indent, boolean bypassCacheRead, Dashboard dash,
-      CdfRunJsDashboardWriteOptions options ) {
+    IThingWriterFactory factory,
+    String indent, boolean bypassCacheRead, Dashboard dash,
+    CdfRunJsDashboardWriteOptions options ) {
     super( factory, indent, bypassCacheRead, dash, options );
-  }
-
-  @Override
-  protected String getRoot() {
-    return this._options.isAbsolute() ?
-      ( !StringUtils.isEmpty( this._options.getAbsRoot() ) ?
-        ( this._options.getSchemedRoot() + "/pentaho/plugin/pentaho-cdf-dd/" )
-        : "/pentaho/plugin/pentaho-cdf-dd/")
-      : "/pentaho/plugin/pentaho-cdf-dd/";
   }
 
   @Override

--- a/cde-pentaho5/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/PentahoCdfRunJsDashboardWriteContextTest.java
+++ b/cde-pentaho5/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/PentahoCdfRunJsDashboardWriteContextTest.java
@@ -1,0 +1,204 @@
+/*!
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+
+package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.amd;
+
+import junit.framework.Assert;
+import org.dom4j.Document;
+import org.dom4j.DocumentException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import pt.webdetails.cdf.dd.model.core.validation.ValidationException;
+import pt.webdetails.cdf.dd.model.inst.Dashboard;
+import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteOptions;
+import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.amd.CdfRunJsThingWriterFactory;
+import pt.webdetails.cdf.dd.model.meta.DashboardType;
+import pt.webdetails.cdf.dd.model.meta.MetaModel;
+import pt.webdetails.cdf.dd.structure.DashboardWcdfDescriptor;
+import pt.webdetails.cdf.dd.util.Utils;
+import pt.webdetails.cpf.repository.util.RepositoryHelper;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+
+
+public class PentahoCdfRunJsDashboardWriteContextTest {
+
+  private static final String ROOT = "test-resources";
+  private static final String TEST_FOLDER = "test";
+  private static final String DASHBOARD = "testDashboard.wcdf";
+  private static final String SYSTEM = "system";
+  private static final String TEST_PLUGIN = "test-plugin";
+
+  private static final String indent = "";
+  private static final boolean bypassCacheRead = true;
+
+  private static CdfRunJsDashboardWriteOptions options;
+  private static CdfRunJsThingWriterFactory factory;
+
+  private static PentahoCdfRunJsDashboardWriteContext context;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    factory = new CdfRunJsThingWriterFactory();
+    options = getCdfRunJsDashboardWriteOptions();
+  }
+
+  @Test
+  public void testReplaceTokensForSolutionDashboard() {
+    //setup context
+    String dashboardPath = RepositoryHelper.joinPaths( ROOT, TEST_FOLDER, DASHBOARD ).substring( 1 );
+    context = new PentahoCdfRunJsDashboardWriteContextForTesting( factory,
+      indent, bypassCacheRead, getDashboard( dashboardPath, false ), options );
+
+    String jsResource = "${res:script.js}";
+    String cssResource = "${res:style.css}";
+    String absoluteResource = "${res:/test-resources/style.css}";
+    String solutionAbsoluteResource = "${solution:script.js}";
+    String solutionRelativeResource = "${solution:/test-resources/script.js}";
+
+    String jsResourceExpected = RepositoryHelper.joinPaths( ROOT, TEST_FOLDER, "script.js" );
+    String cssResourceExpected = RepositoryHelper.joinPaths( ROOT, TEST_FOLDER, "style.css" );
+    String absoluteExpected = RepositoryHelper.joinPaths( ROOT, "style.css" );
+    String solutionAbsoluteResourceExpected = RepositoryHelper.joinPaths( ROOT, TEST_FOLDER, "script.js" );
+    String solutionRelativeResourceExpected = RepositoryHelper.joinPaths( ROOT, "script.js" );
+
+    String jsResourceReplaced = removeParams( context.replaceTokens( jsResource ) );
+    String cssResourceReplaced = removeParams( context.replaceTokens( cssResource ) );
+    String absoluteResourceReplaced = removeParams( context.replaceTokens( absoluteResource ) );
+    String solutionAbsoluteResourceReplaced = removeParams( context.replaceTokens( solutionAbsoluteResource ) );
+    String solutionRelativeResourceReplaced = removeParams( context.replaceTokens( solutionRelativeResource ) );
+
+    Assert.assertEquals( "${res:script.js} replacement failed", jsResourceExpected, jsResourceReplaced );
+    Assert.assertEquals( "${res:style.css} replacement failed", cssResourceExpected, cssResourceReplaced );
+    Assert.assertEquals( "${res:/test-resources/style.css} replacement failed", absoluteExpected,
+      absoluteResourceReplaced );
+    Assert.assertEquals( "${solution:script.js} replacement failed", solutionAbsoluteResourceExpected,
+      solutionAbsoluteResourceReplaced );
+    Assert.assertEquals( "${solution:/test-resources/script.js} replacement failed", solutionRelativeResourceExpected,
+      solutionRelativeResourceReplaced );
+  }
+
+  @Test
+  public void testReplaceTokensForSystemDashboard() {
+    //setup context
+    String dashboardPath =
+      RepositoryHelper.joinPaths( ROOT, SYSTEM, TEST_PLUGIN, TEST_FOLDER, DASHBOARD ).substring( 1 );
+    context = new PentahoCdfRunJsDashboardWriteContextForTesting( factory,
+      indent, bypassCacheRead, getDashboard( dashboardPath, true ), options );
+
+    String systemRelativeResource = "${system:script.js}";
+    String systemAbsoluteResource = "${system:/test/script.js}";
+
+    String systemResourceExpected = RepositoryHelper.joinPaths( SYSTEM, TEST_PLUGIN, TEST_FOLDER, "script.js" );
+
+    String systemAbsoluteResourceReplaced = removeParams( context.replaceTokens( systemAbsoluteResource ) );
+    String systemRelativeResourceReplaced = removeParams( context.replaceTokens( systemRelativeResource ) );
+
+    Assert
+      .assertEquals( "${system:script.js} replacement failed", systemResourceExpected, systemAbsoluteResourceReplaced );
+    Assert.assertEquals( "${system:/test/script.js} replacement failed", systemResourceExpected,
+      systemRelativeResourceReplaced );
+  }
+
+  @Test
+  public void testAbsoluteSchemePaths() {
+    String jsResourceReplaced;
+    //setup context
+    String dashboardPath = RepositoryHelper.joinPaths( ROOT, TEST_FOLDER, DASHBOARD ).substring( 1 );
+
+    options = new CdfRunJsDashboardWriteOptions( false, false, "", "" );
+    context = new PentahoCdfRunJsDashboardWriteContextForTesting( factory,
+      indent, bypassCacheRead, getDashboard( dashboardPath, false ), options );
+
+    String jsResource = "${res:script.js}";
+
+    String jsResourceExpected = RepositoryHelper.joinPaths( ROOT, TEST_FOLDER, "script.js" );
+    String jsResourceAbsoluteExpected = RepositoryHelper.joinPaths( ROOT, TEST_FOLDER, "script.js" );
+
+    jsResourceReplaced = removeParams( context.replaceTokens( jsResource ) );
+    Assert.assertEquals( "${res:script.js} replacement failed", jsResourceExpected, jsResourceReplaced );
+
+    options = new CdfRunJsDashboardWriteOptions( true, false, "localhost:8080", "http" );
+    context = new PentahoCdfRunJsDashboardWriteContextForTesting( factory,
+      indent, bypassCacheRead, getDashboard( dashboardPath, false ), options );
+
+    jsResourceReplaced = removeParams( context.replaceTokens( jsResource ) );
+    Assert.assertEquals( "${res:script.js} replacement failed", jsResourceAbsoluteExpected, jsResourceReplaced );
+
+    options = new CdfRunJsDashboardWriteOptions( false, false, "localhost:8080", "http" );
+    context = new PentahoCdfRunJsDashboardWriteContextForTesting( factory,
+      indent, bypassCacheRead, getDashboard( dashboardPath, false ), options );
+
+    jsResourceReplaced = removeParams( context.replaceTokens( jsResource ) );
+    Assert.assertEquals( "${res:script.js} replacement failed", jsResourceExpected, jsResourceReplaced );
+
+
+  }
+
+
+  private static Dashboard getDashboard( String path, boolean isSystem ) {
+    Document wcdfDoc = null;
+    try {
+      wcdfDoc = Utils.getDocument( new FileInputStream( new File( path ) ) );
+    } catch ( DocumentException e ) {
+      e.printStackTrace();
+    } catch ( FileNotFoundException e ) {
+      e.printStackTrace();
+    }
+    DashboardWcdfDescriptor wcdf = DashboardWcdfDescriptor.fromXml( wcdfDoc );
+    Dashboard.Builder builder = new Dashboard.Builder();
+    DashboardType dashboardType = null;
+    try {
+      dashboardType = new DashboardType.Builder().build();
+    } catch ( ValidationException e ) {
+      e.printStackTrace();
+    }
+
+    if ( !isSystem ) {
+      builder.setSourcePath( path );
+    } else {
+      // this is needed because we need to remove the test-resources path used to get the file
+      // this is secure because there are no folder before the system while getting files from the server
+      builder.setSourcePath( path.replace( ROOT + "/", "" ) );
+    }
+
+    builder.setWcdf( wcdf );
+    builder.setMeta( dashboardType );
+    MetaModel.Builder metaBuilder = new MetaModel.Builder();
+    MetaModel model;
+    Dashboard dashboard = null;
+    try {
+      model = metaBuilder.build();
+      dashboard = builder.build( model );
+
+    } catch ( ValidationException e ) {
+      e.printStackTrace();
+    }
+    return dashboard;
+  }
+
+  private static CdfRunJsDashboardWriteOptions getCdfRunJsDashboardWriteOptions() {
+    boolean absolute = false;
+    boolean debug = false;
+    String absRoot = "";
+    String scheme = "";
+    return new CdfRunJsDashboardWriteOptions( absolute, debug, absRoot, scheme );
+  }
+
+  private String removeParams( String msg ) {
+    return msg.substring( 0, msg.indexOf( "?" ) );
+  }
+
+}

--- a/cde-pentaho5/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/legacy/PentahoCdfRunJsDashboardWriteContextForTesting.java
+++ b/cde-pentaho5/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/legacy/PentahoCdfRunJsDashboardWriteContextForTesting.java
@@ -1,0 +1,47 @@
+/*!
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+
+package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.legacy;
+
+import org.apache.commons.lang.StringUtils;
+import pt.webdetails.cdf.dd.model.core.writer.IThingWriterFactory;
+import pt.webdetails.cdf.dd.model.inst.Dashboard;
+import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteOptions;
+
+public class PentahoCdfRunJsDashboardWriteContextForTesting extends PentahoCdfRunJsDashboardWriteContext {
+  public PentahoCdfRunJsDashboardWriteContextForTesting(
+      IThingWriterFactory factory,
+      String indent, boolean bypassCacheRead, Dashboard dash,
+      CdfRunJsDashboardWriteOptions options ) {
+    super( factory, indent, bypassCacheRead, dash, options );
+  }
+
+  @Override
+  protected String getRoot() {
+    return this._options.isAbsolute() ?
+      ( !StringUtils.isEmpty( this._options.getAbsRoot() ) ?
+        ( this._options.getSchemedRoot() + "/pentaho/plugin/pentaho-cdf-dd/" )
+        : "/pentaho/plugin/pentaho-cdf-dd/")
+      : "/pentaho/plugin/pentaho-cdf-dd/";
+  }
+
+  @Override
+  protected String getSystemDir() {
+    return "system";
+  }
+
+  @Override
+  protected String getPluginId(String path) {
+    return "test-plugin";
+  }
+}

--- a/cde-pentaho5/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/legacy/PentahoCdfRunJsDashboardWriteContextTest.java
+++ b/cde-pentaho5/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/legacy/PentahoCdfRunJsDashboardWriteContextTest.java
@@ -1,4 +1,17 @@
-package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard;
+/*!
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+
+package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.legacy;
 
 import junit.framework.Assert;
 import org.dom4j.Document;
@@ -7,6 +20,7 @@ import org.junit.Test;
 import org.junit.BeforeClass;
 import pt.webdetails.cdf.dd.model.core.validation.ValidationException;
 import pt.webdetails.cdf.dd.model.inst.Dashboard;
+import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteOptions;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.legacy.CdfRunJsThingWriterFactory;
 import pt.webdetails.cdf.dd.model.meta.DashboardType;
 import pt.webdetails.cdf.dd.model.meta.MetaModel;


### PR DESCRIPTION
	- changed CSS external resource loading, now using css! RequireJS loader plugin
	- fixed JS external resource paths for embedded dashboards
	- added cdo and Utils as default libs for dashboards required using the getDashboard endpoint, same as when rendered
	- unit tests