### PR TITLE
[CDE-604] JS File Resources with no name break the resource order

### DIFF
--- a/cde-core/src/pt/webdetails/cdf/dd/CdeConstants.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/CdeConstants.java
@@ -162,9 +162,11 @@ public class CdeConstants {
     // make the dashboard variable available in the global scope to facilitate debugging
     public static final String DASHBOARD_DECLARATION_DEBUG = "window.dashboard = new Dashboard({0});" + NEWLINE;
     public static final String DASHBOARD_INIT = "dashboard.init();" + NEWLINE;
-    public static final String REQUIRE_START = "require([''{0}'']," + NEWLINE + "function({1}) '{'";
+    public static final String REQUIRE_START = "require([" + NEWLINE + INDENT1 + "''{0}''],"
+        + NEWLINE + "function(" + NEWLINE + INDENT1 + "{1}) '{'" + NEWLINE;
     public static final String REQUIRE_STOP = "return dashboard;" + NEWLINE + "});";
-    public static final String DEFINE_START = "define([''{0}'']," + NEWLINE + INDENT1 + "function({1}) '{'" + NEWLINE;
+    public static final String DEFINE_START = "define([" + NEWLINE + INDENT1 + "''{0}''],"
+        + NEWLINE + INDENT1 + "function(" + NEWLINE + INDENT1 + "{1}) '{'" + NEWLINE;
     public static final String DEFINE_STOP = "return CustomDashboard;" + NEWLINE + "});";
     public static final String DASHBOARD_MODULE_START_EMPTY_ALIAS =
         "var CustomDashboard = Dashboard.extend('{'" + NEWLINE
@@ -228,7 +230,7 @@ public class CdeConstants {
     public static final String RESOURCE_AMD_NAMESPACE = "cde/resources";
     public static final String REQUIRE_PATH_CONFIG = "requireCfg[''paths''][''{0}''] = "
         + "CONTEXT_PATH + ''plugin/pentaho-cdf-dd/api/resources{1}'';";
-    public static final String REQUIRE_PATH_CONFIG_FULL_URI = "requireCfg[''paths''][''{0}''] = ''{1}''";
+    public static final String REQUIRE_PATH_CONFIG_FULL_URI = "requireCfg[''paths''][''{0}''] = ''{1}'';";
     public static final String REQUIRE_CONFIG = "require.config(requireCfg);";
 
     // legacy

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriter.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriter.java
@@ -531,8 +531,8 @@ public class CdfRunJsDashboardWriter extends JsWriterAbstract implements IThingW
     out
       .append( MessageFormat.format(
         REQUIRE_START,
-        StringUtils.join( ids, "', '" ),
-        StringUtils.join( classNames, ", " ) ) )
+        StringUtils.join( ids, "'," + NEWLINE + INDENT1 + "'" ),
+        StringUtils.join( classNames, "," + NEWLINE + INDENT1 ) ) )
       .append( NEWLINE );
   }
 
@@ -577,41 +577,58 @@ public class CdfRunJsDashboardWriter extends JsWriterAbstract implements IThingW
       CdfRunJsDashboardWriteContext ctx ) {
 
     Map<String, String> resourceModules = new LinkedHashMap<String, String>();
+    // File Resources with empty names should be placed last in the array dependency list
+    Map<String, String> unnamedResourceModules = new LinkedHashMap<String, String>();
+    String path;
+    StringBuilder id = new StringBuilder();
 
     // JS
     for ( ResourceMap.Resource resource : resources.getJavascriptResources() ) {
       if ( resource.getResourceType().equals( ResourceMap.ResourceType.FILE ) ) {
 
-        String path = resource.getResourcePath();
-
-        String id;
+        // replace tokens and alias
+        path = ctx.replaceTokensAndAlias( resource.getResourcePath() );
+        // reset
+        id.setLength( 0 );
 
         // full URI
         if ( SCHEME_PATTERN.matcher( path ).find() ) {
 
-          id = RESOURCE_AMD_NAMESPACE + "/"
-            + ( StringUtils.isEmpty( resource.getResourceName() )
-              ? "R" + UUID.randomUUID()/*.toString().replace( "-", "" )*/
-              :  resource.getResourceName() );
+          if ( StringUtils.isEmpty( resource.getResourceName() ) ) {
+            id.append( RESOURCE_AMD_NAMESPACE ).append( "/" ).append( getRandomUUID() );
+            // store the generated module id and class name to be added at the end of the dependency array
+            unnamedResourceModules.put( id.toString(), resource.getResourceName() );
+          } else {
+            id.append( RESOURCE_AMD_NAMESPACE ).append( "/" ).append( resource.getResourceName() );
+            // store the generated module id and class name
+            resourceModules.put( id.toString(), resource.getResourceName() );
+          }
+
           // output RequireJS path configuration
           out.append( MessageFormat.format( REQUIRE_PATH_CONFIG_FULL_URI, id, path.replaceFirst( "(?i).js$", "" ) ) )
             .append( NEWLINE );
 
         } else {
+
           // normalize the path
-          path = Util.normalizeUri( ctx.replaceTokensAndAlias( resource.getResourcePath() ) );
+          path = Util.normalizeUri( path );
           if ( path.startsWith( "/" ) ) {
             path =  path.replaceFirst( "/", "" );
           }
 
           // remove file extension
-          id = RESOURCE_AMD_NAMESPACE + "/" + path.replaceFirst( "(?i).js$", "" );
+          id.append( RESOURCE_AMD_NAMESPACE ).append( "/" ).append( path.replaceFirst( "(?i).js$", "" ) );
+
+          if ( StringUtils.isEmpty( resource.getResourceName() ) ) {
+            // store the generated module id and class name to be added at the end of the dependency array
+            unnamedResourceModules.put( id.toString(), resource.getResourceName() );
+          } else {
+            // store the generated module id and class name, maintain order
+            resourceModules.put( id.toString(), resource.getResourceName() );
+          }
+
           // no need for RequireJS path configuration (built based on cde-require-js-cfg.js cde/resources/)
-
         }
-
-        // store the generated module id and class name
-        resourceModules.put( id, resource.getResourceName() );
       }
     }
 
@@ -619,35 +636,39 @@ public class CdfRunJsDashboardWriter extends JsWriterAbstract implements IThingW
     for ( ResourceMap.Resource resource : resources.getCssResources() ) {
       if ( resource.getResourceType().equals( ResourceMap.ResourceType.FILE ) ) {
 
-        String path = resource.getResourcePath();
-        String id;
+        // replace tokens and alias
+        path = ctx.replaceTokensAndAlias( resource.getResourcePath() );
+        // reset
+        id.setLength( 0 );
 
         // full URI
         if ( SCHEME_PATTERN.matcher( path ).find() ) {
 
-          id = RESOURCE_AMD_NAMESPACE + "/"
-            + ( StringUtils.isEmpty( resource.getResourceName() )
-            ? "R" + UUID.randomUUID()/*.toString().replace( "-", "" )*/
-            :  resource.getResourceName() );
+          id.append( RESOURCE_AMD_NAMESPACE )
+            .append( "/" )
+            .append( ( StringUtils.isEmpty( resource.getResourceName() ) ? getRandomUUID() : resource.getResourceName() ) );
           // output RequireJS path configuration
           out.append( MessageFormat.format( REQUIRE_PATH_CONFIG_FULL_URI, id, path.replaceFirst( "(?i).css$", "" ) ) )
             .append( NEWLINE );
 
         } else {
+
           // normalize the path
-          path = Util.normalizeUri( ctx.replaceTokensAndAlias( resource.getResourcePath() ) );
+          path = Util.normalizeUri( path );
           if ( path.startsWith( "/" ) ) {
             path = path.replaceFirst( "/", "" );
           }
 
           // remove file extension
-          id = RESOURCE_AMD_NAMESPACE + "/" + path.replaceFirst( "(?i).css$", "" );
+          id.append( RESOURCE_AMD_NAMESPACE )
+            .append( "/" )
+            .append( path.replaceFirst( "(?i).css$", "" ) );
           // no need for RequireJS path configuration (built based on cde-require-js-cfg.js cde/resources/)
 
         }
 
         // prepend css! RequireJS loader plugin and don't provide a class name for CSS resources
-        resourceModules.put(  RequireJSPlugin.CSS + id, ""/*resource.getResourceName()*/ );
+        resourceModules.put( RequireJSPlugin.CSS + id.toString(), "" );
 
       }
     }
@@ -657,7 +678,19 @@ public class CdfRunJsDashboardWriter extends JsWriterAbstract implements IThingW
       out.append( REQUIRE_CONFIG ).append( NEWLINE );
     }
 
+    // Finally append the unnamed JS file resources to be added at the end of the dependency array
+    resourceModules.putAll( unnamedResourceModules );
+
     return resourceModules;
+  }
+
+  /**
+   * Generates a UUID to be used as part of an AMD module id.
+   *
+   * @return the string containing the random UUID value
+   */
+  protected String getRandomUUID() {
+    return UUID.randomUUID().toString();
   }
 
   /**

--- a/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriterTest.java
+++ b/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriterTest.java
@@ -367,8 +367,8 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     StringBuilder dashboardResult = new StringBuilder();
 
     dashboardResult
-      .append( MessageFormat.format( REQUIRE_START, StringUtils.join( moduleIds, "', '" ),
-        StringUtils.join( moduleClassNames, ", " ) ) ).append( NEWLINE )
+      .append( MessageFormat.format( REQUIRE_START, StringUtils.join( moduleIds, "'," + NEWLINE + INDENT1 + "'" ),
+        StringUtils.join( moduleClassNames, "," + NEWLINE + INDENT1 ) ) ).append( NEWLINE )
       .append( MessageFormat.format( DASHBOARD_DECLARATION, CONTEXT_CONFIGURATION  ) )
       .append( "jsCodeRsrc1" ).append( NEWLINE )
       .append( content ).append( NEWLINE )
@@ -383,8 +383,8 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     doReturn( true ).when( options ).isDebug();
     dashboardResult.setLength( 0 );
     dashboardResult
-      .append( MessageFormat.format( REQUIRE_START, StringUtils.join( moduleIds, "', '" ),
-        StringUtils.join( moduleClassNames, ", " ) ) )
+      .append( MessageFormat.format( REQUIRE_START, StringUtils.join( moduleIds, "'," + NEWLINE + INDENT1 + "'" ),
+        StringUtils.join( moduleClassNames, "," + NEWLINE + INDENT1 ) ) )
       .append( NEWLINE )
       .append( MessageFormat.format( DASHBOARD_DECLARATION_DEBUG, CONTEXT_CONFIGURATION  ) )
       .append( "jsCodeRsrc1" ).append( NEWLINE )
@@ -427,9 +427,13 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     dashboardWriterSpy.writeRequireJsExecutionFunction( out, moduleIds, moduleClassNames );
 
     Assert.assertEquals(
-        MessageFormat.format( REQUIRE_START,
-        "cdf/components/TestComponent1', 'cde/resources/jsFileRsrc1', 'css!cde/resources/cssFileRsrc1",
-        "TestComponent1, jsFileRsrc1" ) + NEWLINE,
+        MessageFormat.format(
+          REQUIRE_START,
+          "cdf/components/TestComponent1',"
+            + NEWLINE + INDENT1 + "'cde/resources/jsFileRsrc1',"
+            + NEWLINE + INDENT1 + "'css!cde/resources/cssFileRsrc1",
+          "TestComponent1,"
+            + NEWLINE + INDENT1 + "jsFileRsrc1" ) + NEWLINE,
         out.toString() );
   }
 
@@ -448,17 +452,22 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
   @Test
   public void testWriteFileResourcesRequireJSPathConfig() {
     StringBuilder out = new StringBuilder();
+    doReturn( "1234" ).when( dashboardWriterSpy ).getRandomUUID();
     // resources
     ResourceMap testResources = new ResourceMap();
-    testResources.add( ResourceKind.JAVASCRIPT, ResourceType.FILE, "jsFileRsrc1", "jsFileRsrcPath1", "jsFileRsrc1" );
     // unnamed file resource
     testResources.add( ResourceKind.JAVASCRIPT, ResourceType.FILE, "", "a/path/../file2.js", "jsFileRsrc2" );
+    // named file resource
+    testResources.add( ResourceKind.JAVASCRIPT, ResourceType.FILE, "jsFileRsrc1", "jsFileRsrcPath1", "jsFileRsrc1" );
     // file resource not normalized
     testResources.add( ResourceKind.JAVASCRIPT, ResourceType.FILE, "jsFileRsrc3", "a/path/../file3.js", "jsFileRsrc3" );
     testResources.add( ResourceKind.JAVASCRIPT, ResourceType.CODE, "jsCodeRsrc1", "jsCodeRsrcrPath1", "jsCodeRsrc1" );
     // absolute file resource
     testResources.add( ResourceKind.JAVASCRIPT, ResourceType.FILE, "jsFileRsrc4", "http://dummy/jsFileRsrcPath4.js",
         "jsFileRsrc4" );
+    // absolute unnamed file resource
+    testResources.add( ResourceKind.JAVASCRIPT, ResourceType.FILE, "", "http://dummy/jsFileRsrcPath5.js",
+        "jsFileRsrc5" );
     testResources.add( ResourceKind.CSS, ResourceType.FILE, "cssFileRsrc1", "cssFileRsrcPath1", "cssFileRsrc1" );
     testResources.add( ResourceKind.CSS, ResourceType.FILE, "cssFileRsrc2", "cssFileRsrcPath2.css", "cssFileRsrc2" );
     testResources.add( ResourceKind.CSS, ResourceType.CODE, "cssCodeRsrc1", "cssCodeRsrcPath1", "cssCodeRsrc1" );
@@ -469,8 +478,14 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     doReturn( "jsFileRsrcPath1" ).when( context ).replaceTokensAndAlias( "jsFileRsrcPath1" );
     doReturn( "a/path/../file2.js" ).when( context ).replaceTokensAndAlias( "a/path/../file2.js" );
     doReturn( "a/path/../file3.js" ).when( context ).replaceTokensAndAlias( "a/path/../file3.js" );
+    doReturn( "http://dummy/jsFileRsrcPath4.js" )
+      .when( context ).replaceTokensAndAlias( "http://dummy/jsFileRsrcPath4.js" );
+    doReturn( "http://dummy/jsFileRsrcPath5.js" )
+      .when( context ).replaceTokensAndAlias( "http://dummy/jsFileRsrcPath5.js" );
     doReturn( "cssFileRsrcPath1" ).when( context ).replaceTokensAndAlias( "cssFileRsrcPath1" );
     doReturn( "cssFileRsrcPath2.css" ).when( context ).replaceTokensAndAlias( "cssFileRsrcPath2.css" );
+    doReturn( "http://dummy/cssFileRsrcPath3.css" )
+      .when( context ).replaceTokensAndAlias( "http://dummy/cssFileRsrcPath3.css" );
 
     Map<String, String> resourceModules =
         dashboardWriterSpy.writeFileResourcesRequireJSPathConfig( out, testResources, context );
@@ -478,12 +493,14 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     assertEquals( "", resourceModules.get( "cde/resources/a/file2" ) );
     assertEquals( "jsFileRsrc3", resourceModules.get( "cde/resources/a/file3" ) );
     assertEquals( "jsFileRsrc4", resourceModules.get( "cde/resources/jsFileRsrc4" ) );
+    assertEquals( "", resourceModules.get( "cde/resources/1234" ) ); // random UUID mocked value
     assertEquals( "", resourceModules.get( "css!cde/resources/cssFileRsrcPath1" ) );
     assertEquals( "", resourceModules.get( "css!cde/resources/cssFileRsrcPath2" ) );
     assertEquals( "", resourceModules.get( "css!cde/resources/cssFileRsrc3" ) );
 
-    assertEquals( "requireCfg['paths']['cde/resources/jsFileRsrc4'] = 'http://dummy/jsFileRsrcPath4'\n"
-        + "requireCfg['paths']['cde/resources/cssFileRsrc3'] = 'http://dummy/cssFileRsrcPath3'\n"
+    assertEquals( "requireCfg['paths']['cde/resources/jsFileRsrc4'] = 'http://dummy/jsFileRsrcPath4';\n"
+        + "requireCfg['paths']['cde/resources/1234'] = 'http://dummy/jsFileRsrcPath5';\n"
+        + "requireCfg['paths']['cde/resources/cssFileRsrc3'] = 'http://dummy/cssFileRsrcPath3';\n"
         + "require.config(requireCfg);", out.toString().trim() );
 
     Map<String, String> expectedResourceModules = new LinkedHashMap<String, String>();
@@ -494,6 +511,8 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     expectedResourceModules.put( "css!cde/resources/cssFileRsrcPath1", "" );
     expectedResourceModules.put( "css!cde/resources/cssFileRsrcPath2", "" );
     expectedResourceModules.put( "css!cde/resources/cssFileRsrc3", "" );
+    // unnamed file resource from full URI (UUID) will come last
+    expectedResourceModules.put( "cde/resources/1234", "" );
 
     assertEquals( expectedResourceModules, resourceModules );
   }


### PR DESCRIPTION
    - unnamed js external file resources, that are not used in the RequireJS require/define callback function, come last in the AMD module dependency array
    - prettified RequireJS require/define function headers and fixed unterminated statements when defining AMD module paths