### PR TITLE
[CDE-615] - Not using a default button style, so we can tie it to the dashboard rendererType

### DIFF
--- a/cde-core/resource/resources/base/components/others/ButtonRender.xml
+++ b/cde-core/resource/resources/base/components/others/ButtonRender.xml
@@ -12,7 +12,7 @@
         <Model>
             <Property>label</Property>
             <Property>htmlObject</Property>
-            <Property name="buttonStyle">tableStyle</Property>
+            <Property>buttonStyle</Property>
             <Property>executeAtStart</Property>
             <Property>listeners</Property>
             <Property>preExecution</Property>
@@ -82,6 +82,20 @@
                         <Advanced>true</Advanced>
 	                <Order>40</Order>
 	                <Version>1.0</Version>
+                    </Header>
+                </DesignerProperty>
+                <DesignerProperty>
+                    <Header>
+                        <Name>buttonStyle</Name>
+                        <Parent>BaseProperty</Parent>
+                        <DefaultValue></DefaultValue>
+                        <Description>Style</Description>
+                        <Tooltip>Button Style</Tooltip>
+                        <Advanced>true</Advanced>
+                        <InputType>TableStyle</InputType>
+                        <OutputType>String</OutputType>
+                        <Order>56</Order>
+                        <Version>1.0</Version>
                     </Header>
                 </DesignerProperty>
             </CustomProperties>

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriter.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriter.java
@@ -244,7 +244,7 @@ public class CdfRunJsDashboardWriter extends JsWriterAbstract implements IThingW
 
     // Output WCDF
     try {
-      addAssignment( out, "var wcdfSettings", wcdf.toJSON().toString( 2 ) );
+      addAssignment( out, "var wcdfSettings = dashboard.wcdfSettings", wcdf.toJSON().toString( 2 ) );
     } catch ( JSONException ex ) {
       throw new ThingWriteException( "Converting wcdf to json", ex );
     }

--- a/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriterTest.java
+++ b/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriterTest.java
@@ -219,7 +219,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     Map<String, String> componentModules = dashboardWriterSpy.writeComponents( context, dash, out );
 
     Assert.assertEquals(
-        "var wcdfSettings = {};" + NEWLINE + NEWLINE + NEWLINE
+        "var wcdfSettings = dashboard.wcdfSettings = {};" + NEWLINE + NEWLINE + NEWLINE
         + "dashboard.addComponents([comp1, comp2, comp3]);" + NEWLINE,
         out.toString() );
 


### PR DESCRIPTION

- Exposing wcdfSettings in the dashboard object, so it is available in a broader scope.