### PR TITLE
[CDE-615] - Removing the default from the tableStyle so we can take a…

### DIFF
--- a/cde-core/resource/js/cdf-dd-palletemanager.js
+++ b/cde-core/resource/js/cdf-dd-palletemanager.js
@@ -195,10 +195,6 @@ var PalleteEntry = Base.extend({
 
     var _stub = stub != undefined ? stub : this.getStub();
 
-    if( rendererType == "bootstrap" && this.id == "TABLE_ENTRY" ) {
-      this.changeProperty( _stub, "tableStyle", "bootstrap" )
-    }
-
     var rowIdx;
     var colIdx = 0;
     var rowId;

--- a/cde-core/resource/js/cdf-dd.js
+++ b/cde-core/resource/js/cdf-dd.js
@@ -1407,46 +1407,6 @@ var CDFDD = Base.extend({
       file: CDFDDFileName.replace(".cdfde", ".wcdf")
     }, wcdf);
 
-    var newRenderer = saveSettingsParams.rendererType;
-    var oldRenderer = cdfdd.getDashboardWcdf().rendererType;
-    var toUpdate = [];
-
-    //if the renderer type changed, then check for the existence of Table Components
-    //that needs to update the style property
-    if(newRenderer != oldRenderer) {
-      var components = cdfdd.getDashboardData().components.rows;
-      _.each(components, function(comp, i) {
-        if(comp.parent == "OTHERCOMPONENTS" && comp.type == "ComponentsTable") {
-          _.each(comp.properties, function(prop, j) {
-            if(prop.name == "tableStyle") {
-              if(( newRenderer != "bootstrap" && prop.value == "bootstrap" ) ||
-                  ( newRenderer == "bootstrap" && prop.value != "bootstrap" )) {
-                toUpdate.push(prop);
-                return;
-              }
-            }
-          });
-        }
-      });
-    }
-
-    if(toUpdate.length) {
-      var message = Dashboards.i18nSupport.prop('SaveSettings.INFO_UPDATE_TABLE_STYLE_PROP') + '\n' +
-          Dashboards.i18nSupport.prop('SaveSettings.CONFIRMATION_UPDATE_TABLE_STYLE_PROP');
-      var updateStyle = confirm(message);
-
-      if(updateStyle) {
-        _.each(toUpdate, function(prop, index) {
-          if(newRenderer == "bootstrap") {
-            prop.value = "bootstrap";
-          } else {
-            prop.value = "themeroller";
-          }
-        });
-        cdfdd.components.initTables();
-      }
-    }
-
     SaveRequests.saveSettings(saveSettingsParams, cdfdd, wcdf, myself);
 
   },

--- a/cde-core/resource/resources/base/properties/TableStyle.xml
+++ b/cde-core/resource/resources/base/properties/TableStyle.xml
@@ -1,8 +1,9 @@
+<!--This property is both used by the TableComponent and the ButtonComponent-->
 <DesignerProperty>
 <Header>
 	<Name>tableStyle</Name>
 	<Parent>BaseProperty</Parent>
-	<DefaultValue>themeroller</DefaultValue>
+	<DefaultValue></DefaultValue>
 	<Description>Style</Description>
 	<Tooltip>Table style</Tooltip>
 	<Advanced>true</Advanced>

--- a/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriter.java
+++ b/cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriter.java
@@ -242,7 +242,7 @@ public class CdfRunJsDashboardWriter extends JsWriterAbstract implements IThingW
     Map<String, String> componentModules = new LinkedHashMap<String, String>();
 
     // Output WCDF
-    addAssignment( out, "var wcdfSettings", wcdf.toJSON().toString( 2 ) );
+    out.append( "dashboard.getWcdfSettings = function() {\n  return " + wcdf.toJSON().toString( 2 ) + "\n};" );
     out.append( NEWLINE );
 
     StringBuilder addCompIds = new StringBuilder();

--- a/cde-core/test-js/legacy/cdf-dd-spec.js
+++ b/cde-core/test-js/legacy/cdf-dd-spec.js
@@ -25,36 +25,4 @@ describe("CDF-DD tests", function() {
     expect(cdfdd.isNewFile('/public/plugin-samples/pentaho-cdf-dd/cde_sample.wcdf')).toBeFalsy();
   });
 
-  it("Save Settings # Change Table Component Style Property", function() {
-
-    var rendererType = undefined;
-    cdfdd.components.initTables = function() {};
-    var table = {
-      id: "table",
-      type: "ComponentsTable",
-      typeDesc: "table Component",
-      parent: "OTHERCOMPONENTS",
-      properties: [{
-        name: "tableStyle",
-        value: "bootstrap"
-      }]
-    };
-
-    spyOn(cdfdd, 'getDashboardData').and.callFake(function() { return { components: {rows: [table]} }; });
-    spyOn(cdfdd, 'getDashboardWcdf').and.callFake(function() { return { rendererType: rendererType }; });
-    spyOn(window, 'confirm').and.returnValue(true);
-    spyOn(SaveRequests, 'saveSettings');
-
-    /*change from bootstrap to blueprint*/
-    rendererType = 'bootstrap';
-    cdfdd.saveSettingsRequest({rendererType:'blueprint'});
-    expect(table.properties[0].value).toBe("themeroller");
-    expect(SaveRequests.saveSettings).toHaveBeenCalled();
-
-    /*change from blueprint to bootstrap*/
-    rendererType = 'blueprint';
-    cdfdd.saveSettingsRequest({rendererType:'bootstrap'});
-    expect(table.properties[0].value).toBe("bootstrap");
-    expect(SaveRequests.saveSettings).toHaveBeenCalled();
-  });
 });

--- a/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriterTest.java
+++ b/cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriterTest.java
@@ -219,7 +219,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     Map<String, String> componentModules = dashboardWriterSpy.writeComponents( context, dash, out );
 
     Assert.assertEquals(
-      "var wcdfSettings = {};" + NEWLINE + NEWLINE + NEWLINE
+        "dashboard.getWcdfSettings = function() {\n  return {}\n};" + NEWLINE + NEWLINE
         + "dashboard.addComponents([comp1, comp2, comp3]);" + NEWLINE,
       out.toString() );
 


### PR DESCRIPTION
…dvantage of an undefined value.

- Editor no longer responsible for tying the table component style to the renderer type.
- Exposing wcdfSettings in the dashboard object, so it is available in a broader scope.

Conflicts:
	cde-core/src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriter.java
	cde-core/test-src/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriterTest.java