### PR TITLE
[CDE-648] - Setting shape opacity and stroke in NewMapComponent

### DIFF
--- a/cde-core/resource/resources/custom/components/NewMapComponent/NewMapComponent.js
+++ b/cde-core/resource/resources/custom/components/NewMapComponent/NewMapComponent.js
@@ -522,9 +522,9 @@ var NewMapComponent = (function () {
       // Define default shape appearance
       var shapeSettings = _.defaults(this.shapeSettings || {}, {
         //fillColor:  'blue',
-        //fillOpacity: 0.5,
+        fillOpacity: this.shapeFillOpacity,
         strokeWidth: 2,
-        strokeColor: 'white',
+        strokeColor: this.shapeStrokeColor,
         zIndex: 0
       });
 

--- a/cde-core/resource/resources/custom/components/NewMapComponent/component.xml
+++ b/cde-core/resource/resources/custom/components/NewMapComponent/component.xml
@@ -42,6 +42,8 @@
       <Property>mapMode</Property>
       <Property>locationResolver</Property>
       <Property>shapeSource</Property>
+      <Property>shapeFillOpacity</Property>
+      <Property>shapeStrokeColor</Property>
       <Property>colormap</Property>
       <Property>tilesets</Property>
       <Property>shapeMouseOver</Property>
@@ -105,6 +107,34 @@
             <DefaultValue></DefaultValue>
             <Description>Shape definitions</Description>
             <Tooltip>JSON or KML file containing the definitions of the shapes</Tooltip>
+            <Advanced>false</Advanced>
+            <InputType>String</InputType>
+            <OutputType>String</OutputType>
+            <Order>40</Order>
+            <Version>1.0</Version>
+          </Header>
+        </DesignerProperty>
+        <DesignerProperty>
+          <Header>
+            <Name>shapeFillOpacity</Name>
+            <Parent>BaseProperty</Parent>
+            <DefaultValue>0.5</DefaultValue>
+            <Description>Shape Fill Opacity</Description>
+            <Tooltip>Value of shape's opacity (from 0 to 1)</Tooltip>
+            <Advanced>false</Advanced>
+            <InputType>Float</InputType>
+            <OutputType>Number</OutputType>
+            <Order>40</Order>
+            <Version>1.0</Version>
+          </Header>
+        </DesignerProperty>
+        <DesignerProperty>
+          <Header>
+            <Name>shapeStrokeColor</Name>
+            <Parent>BaseProperty</Parent>
+            <DefaultValue></DefaultValue>
+            <Description>Shape Stroke Color</Description>
+            <Tooltip>Define a color for shape's borders</Tooltip>
             <Advanced>false</Advanced>
             <InputType>String</InputType>
             <OutputType>String</OutputType>


### PR DESCRIPTION
Added support to expose shape's opacity and stroke in NewMapComponent properties configuration