### PR TITLE
[CLEANUP] The "Shape Definition" property of the NewMapComponent should be optional when using shapeResolver addIns

### DIFF
--- a/cde-core/resource/resources/custom/amd-components/NewMapComponent/NewMapComponent.js
+++ b/cde-core/resource/resources/custom/amd-components/NewMapComponent/NewMapComponent.js
@@ -369,7 +369,7 @@ define([
         };
 
         var me = this;
-        if ((this.mapMode == "shapes") && (!_.isEmpty(this.shapeSource))) {
+        if (this.mapMode == "shapes") {
           var keys = _.pluck(json.resultset, idx.id);
           this.dataRequest(this.shapeSource, keys, json)
             .then(function () {
@@ -382,8 +382,8 @@ define([
 
       dataRequest: function (url, keys, json) {
         var addIn = this.getAddIn('ShapeResolver', this.shapeResolver);
-        if (!addIn) {
-          if (this.shapeSource.endsWith('json')) {
+        if (!addIn && this.shapeSource) {
+          if (this.shapeSource.endsWith('json') || this.shapeSource.endsWith('js')) {
             addIn = this.getAddIn('ShapeResolver', 'simpleJSON');
           } else {
             addIn = this.getAddIn('ShapeResolver', 'kml');

--- a/cde-core/resource/resources/custom/components/NewMapComponent/NewMapComponent.js
+++ b/cde-core/resource/resources/custom/components/NewMapComponent/NewMapComponent.js
@@ -334,7 +334,7 @@ var NewMapComponent = (function () {
       };
 
       var me = this;
-      if ((this.mapMode == "shapes") && (!_.isEmpty(this.shapeSource))) {
+      if (this.mapMode == "shapes") {
         var keys = _.pluck(json.resultset, idx.id);
         this.dataRequest(this.shapeSource, keys, json)
             .then(function () {
@@ -347,8 +347,8 @@ var NewMapComponent = (function () {
 
     dataRequest: function (url, keys, json) {
       var addIn = this.getAddIn('ShapeResolver', this.shapeResolver);
-      if (!addIn) {
-        if (this.shapeSource.endsWith('json')) {
+      if (!addIn && this.shapeSource) {
+        if (this.shapeSource.endsWith('json') || this.shapeSource.endsWith('js')) {
           addIn = this.getAddIn('ShapeResolver', 'simpleJSON');
         } else {
           addIn = this.getAddIn('ShapeResolver', 'kml');


### PR DESCRIPTION
This is mostly for convenience, but also avoids confusion and covers a corner usecase.
@pamval please review.