### PR TITLE
[SP-2547] - Backport of PPP-3455 - Dynamic code injection vulnerabilities found (5.4 Suite)

### DIFF
--- a/cde-core/resource/js/cdf-dd-components-selectors.js
+++ b/cde-core/resource/js/cdf-dd-components-selectors.js
@@ -31,10 +31,13 @@ var ListenersRenderer = SelectMultiRenderer.extend({
     var data = Panel.getPanel(ComponentsPanel.MAIN_PANEL).getParameters();
     var _str = "{";
     $.each(data, function(i, val) {
-      _str += "'" + val.properties[0].value + "': '" + val.properties[0].value + "',";
+      _str += '"' + val.properties[0].value + '": "' + val.properties[0].value + '",';
     });
 
-    _str += " 'selected':" + (this.value.replace(/\$\{p:(.+?)\}/g, '$1')) + "}";
+    // this.value is already enclosured, but the enclosure can be both ' and "
+    // hence replace all ' with "
+    var selected = this.value.replace(/\$\{p:(.+?)\}/g, '$1').replace(/\'/g, '"');
+    _str += ' "selected":' + selected + "}";
     return _str;
   },
 

--- a/cde-core/resource/js/cdf-dd-tablemanager.js
+++ b/cde-core/resource/js/cdf-dd-tablemanager.js
@@ -1490,8 +1490,8 @@ var SelectMultiRenderer = CellRenderer.extend({
       if(typeof myself.postProcessValue == "function") {
         val = myself.postProcessValue(val);
       }
-      var value = "['" + val.replace(/, /g, "','") + "']";
-      if(value == "['${p:Select options}']") {
+      value = '["' + val.replace(/, /g, '","') + '"]';
+      if(value === '["${p:Select options}"]') {
         value = "[]";
       }
       myself.logger.debug("Saving new value: " + value);

--- a/cde-core/resource/js/cdf-dd-util.js
+++ b/cde-core/resource/js/cdf-dd-util.js
@@ -49,7 +49,7 @@ Util.parseJsonResult = function(jsonStr){
 	var json = { status : false, result : 'Could not parse result.' }
 	if(jsonStr){
 		try{
-		 json = eval("(" + jsonStr + ")");//ToDo: is jquery's json parser a viable alternative?
+		  json = JSON.parse(jsonStr);
 		}
 		catch (e) {
 			this.logger.error('Could not parse json result �' + jsonStr + '�, ' + e);

--- a/cde-core/resource/js/cdf-dd.js
+++ b/cde-core/resource/js/cdf-dd.js
@@ -1751,11 +1751,12 @@ $(function() {
     },
     content: function(data, settings, original) {
       // If it is string assume it is an array.
+      var json;
       if(String == data.constructor) {
-        eval('var json = ' + data);
+        json = JSON.parse(data);
       } else {
         // Otherwise assume it is a hash already.
-        var json = data;
+        json = data;
       }
       for(var key in json) {
         if(!json.hasOwnProperty(key)) {

--- a/cde-pentaho/resource/js/cdf-dd-base.js
+++ b/cde-pentaho/resource/js/cdf-dd-base.js
@@ -385,7 +385,7 @@ var SaveRequests = {
 
     $.post(wd.cde.endpoints.getPluginUrl() + "Syncronize", saveSettingsParams, function(result) {
       try {
-        var json = eval("(" + result + ")");
+        var json = JSON.parse(result);
         if(json.status == "true") {
           myself.setDashboardWcdf(wcdf);
           // We need to reload the layout engine in case the rendererType changed
@@ -405,7 +405,7 @@ var SaveRequests = {
     var successFunction = function(result) {
       //$.getJSON("/pentaho/content/pentaho-cdf-dd/Syncronize", saveParams, function(json) {
       try {
-        var json = eval("(" + result + ")");
+        var json = JSON.parse(result);
         if(json.status == "true") {
           if(stripArgs.needsReload) {
             window.location.reload();
@@ -445,7 +445,7 @@ var SaveRequests = {
 
     var successFunction = function(result) {
       try {
-        var json = eval("(" + result + ")");
+        var json = JSON.parse(result);
         if(json.status == "true") {
           if(selectedFolder[0] == "/") {
             selectedFolder = selectedFolder.substring(1, selectedFolder.length);
@@ -540,7 +540,19 @@ var LoadRequests = {
     }
 
     $.post(wd.cde.endpoints.getPluginUrl() + "Syncronize", loadParams, function(result) {
-      var json = eval("(" + eval("(" + result + ")").result + ")");
+      var tmp = JSON.parse(result);
+
+      var json;
+      if (tmp) {
+        if (typeof tmp.result === 'string') {
+          json = JSON.parse(tmp.result);
+        } else {
+          json = tmp.result;
+        }
+      } else {
+        json = undefined;
+      }
+
       if(json && json.status == "true") {
         myself.setDashboardData(myself.unstrip(json.result.data));
         myself.setDashboardWcdf(json.result.wcdf);
@@ -567,7 +579,7 @@ var PreviewRequests = {
 
     var successFunction = function(result) {
       try {
-        var json = eval("(" + result + ")");
+        var json = JSON.parse(result);
         if(json.status == "true") {
           $.fancybox({
             type: "iframe",


### PR DESCRIPTION
- replace `eval()` with `JSON.parse()` in cdf-dd-util.js, cdf-dd-util.js, cdf-dd-base.js
- in ListenersRenderer, amend self-written `obj.toString()` to return well-formed representation
  - also change `value` generating algorithm in cdf-dd-tablemanager.js to follow ECMA standard of JSON string representation
(adopted from 467bc718dbbbe498a6cd857494e88573ef393ddf)

@afrjorge, @pamval, review it please. This is a backport of https://github.com/webdetails/cde/pull/678 