### PR TITLE
[BACKLOG-8388] - Upgrade Jersey to 1.19.1 across the suite for Java 8 compatibility

### DIFF
--- a/cde-pentaho5/ivy.xml
+++ b/cde-pentaho5/ivy.xml
@@ -22,7 +22,7 @@
         <dependency org="javax.servlet"           name="servlet-api"        rev="2.4"                           transitive="false"/>
         <dependency org="javax.ws.rs"             name="javax.ws.rs-api"    rev="2.0"                           transitive="false"/>
         <dependency org="commons-jxpath"          name="commons-jxpath"     rev="1.3"                           transitive="false"/>
-        <dependency org="com.sun.jersey.contribs" name="jersey-multipart"   rev="1.17.1"/>
+        <dependency org="com.sun.jersey.contribs" name="jersey-multipart"   rev="1.19.1"/>
         <dependency org="org.slf4j"               name="slf4j-api"          rev="1.7.5"/>
 
         <dependency org="pentaho" name="cpf-core" rev="${dependency.pentaho-cpf-plugin.revision}" transitive="false" changing="true" />


### PR DESCRIPTION
The fix is needed due to using java 1.8, and incompatibility of asm old version (is used by jersey) reading new java 1.8 features 
The following scope of repositories is upgraded(except webdetails): The list is sorted in the order of build team runs

https://github.com/pentaho/pentaho-reporting
https://github.com/pentaho/mondrian
https://github.com/pentaho/pentaho-kettle
https://github.com/pentaho/pentaho-mondrianschemaworkbench-plugins
https://github.com/pentaho/pentaho-platform
https://github.com/webdetails/cpf
https://github.com/pentaho/pentaho-metaverse
https://github.com/pentaho/pdi-platform-utils-plugin
https://github.com/pentaho/pentaho-data-profiling
https://github.com/pentaho/data-access
https://github.com/pentaho/big-data-plugin
https://github.com/pentaho/pentaho-data-refinery
https://github.com/webdetails/cde
https://github.com/webdetails/cpk
https://github.com/webdetails/cda
https://github.com/pentaho/pentaho-platform-plugin-mobile
https://github.com/pentaho/pentaho-karaf-assembly
https://github.com/pentaho/pentaho-karaf-ee-assembly
https://github.com/pentaho/pdi-sdk-plugins
https://github.com/pentaho/pdi-ee-plugin
https://github.com/pentaho/pdi-agile-bi-plugin
https://github.com/pentaho/pentaho-aggdesigner
https://github.com/pentaho/pentaho-metadata-editor