### PR TITLE
[BACKLOG-11532]

### DIFF
--- a/cde-core/resource/js/cdf-dd.js
+++ b/cde-core/resource/js/cdf-dd.js
@@ -282,8 +282,8 @@ var CDFDD = Base.extend({
     var myself = this;
     if(myself.styles.length > 0) {
       var wcdf = myself.getDashboardWcdf();
-      // Default to Clean or the first available style if Clean isn't available
-      var cleanStyle = myself.styles.indexOf('Clean');
+      // Default to CleanRequire or the first available style if CleanRequire isn't available
+      var cleanStyle = myself.styles.indexOf('CleanRequire');
       if(!wcdf.style) {
         wcdf.style = myself.styles[cleanStyle >= 0 ? cleanStyle : 0];
       }

--- a/cde-pentaho5/src/pt/webdetails/cdf/dd/api/RenderApi.java
+++ b/cde-pentaho5/src/pt/webdetails/cdf/dd/api/RenderApi.java
@@ -405,7 +405,7 @@ public class RenderApi {
     if ( !CdeEnvironment.canCreateContent() ) {
       return "This functionality is limited to users with permission 'Create Content'";
     }
-    return getEditor( path, debug, request.getScheme(), isDefault, response, false );
+    return getEditor( path, debug, request.getScheme(), isDefault, response, true );
   }
 
   @GET


### PR DESCRIPTION
  - Using the CleanRequire template when creating new dashboards in CDE since the default is now requirejs.
  - Changing RenderApi /new endpoint to assume that a new dashboard is amd.