### PR TITLE
[CDE-871] Getting blocked:mixed-content errors when attempting to cre…

### DIFF
--- a/cde-core/resource/resources/cdf-dd.html
+++ b/cde-core/resource/resources/cdf-dd.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="@CDF_RESOURCES_BASE_URL@/js-legacy/lib/blueprint/screen.css" type="text/css">
   <link rel="stylesheet" href="@CDF_RESOURCES_BASE_URL@/js-legacy/lib/fancybox/jquery.fancybox.css" type="text/css">
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-  <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
 
   <title>Webdetails CDE</title>
 </head>


### PR DESCRIPTION
…ate a new CDE Dashboard on server configure for HTTPS protocol only

 - removed http protocol forcing for fonts.googleapis.com link