### PR TITLE
[CDF-964]-Reflected XSS prevention

### DIFF
--- a/cde-pentaho5/ivy.xml
+++ b/cde-pentaho5/ivy.xml
@@ -75,6 +75,8 @@
         <dependency org="org.springframework"          name="spring-expression"    rev="${dependency.spring.framework.revision}" conf="test->default" transitive="false"/>
 
         <dependency org="backport-util-concurrent" name="backport-util-concurrent" rev="3.1"           conf="test->default" transitive="false"/>
+        <dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="1.9.3" conf="test->default" transitive="false"/>
+        <dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.9.3" conf="test->default" transitive="false"/>
 
 
     </dependencies>

--- a/cde-pentaho5/src/pt/webdetails/cdf/dd/api/EditorApi.java
+++ b/cde-pentaho5/src/pt/webdetails/cdf/dd/api/EditorApi.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ * Copyright 2002 - 2017 Webdetails, a Pentaho company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -63,6 +63,8 @@ public class EditorApi {
                          @Context HttpServletResponse response )
     throws IOException {
 
+    path = XSSHelper.getInstance().escape( path );
+
     IResourceLoader loader = getResourceLoader( path );
     IReadAccess reader = loader.getReader();
 
@@ -104,6 +106,8 @@ public class EditorApi {
                            @FormParam( MethodParams.DATA ) @DefaultValue( "" ) String data,
                            @Context HttpServletResponse response ) throws IOException {
 
+    path = XSSHelper.getInstance().escape( path );
+
     IResourceLoader loader = getResourceLoader( path );
     IACAccess access = loader.getAccessControl();
     IRWAccess writer = loader.getWriter();
@@ -132,6 +136,8 @@ public class EditorApi {
   public String createFile( @FormParam( MethodParams.PATH ) @DefaultValue( "" ) String path,
                             @FormParam( MethodParams.DATA ) @DefaultValue( "" ) String data,
                             @Context HttpServletResponse response ) throws IOException {
+
+    path = XSSHelper.getInstance().escape( path );
 
     IResourceLoader loader = getResourceLoader( path );
     IACAccess access = loader.getAccessControl();
@@ -169,6 +175,8 @@ public class EditorApi {
   @Consumes( { APPLICATION_XML, APPLICATION_JSON } )
   public String createFolder( @FormParam( MethodParams.PATH ) @DefaultValue( "" ) String path,
                               @Context HttpServletResponse response ) throws IOException {
+
+    path = XSSHelper.getInstance().escape( path );
 
     IResourceLoader loader = getResourceLoader( path );
     IReadAccess reader = loader.getReader();

--- a/cde-pentaho5/src/pt/webdetails/cdf/dd/api/RenderApi.java
+++ b/cde-pentaho5/src/pt/webdetails/cdf/dd/api/RenderApi.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2016 Webdetails, a Pentaho company. All rights reserved.
+ * Copyright 2002 - 2017 Webdetails, a Pentaho company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -102,6 +102,12 @@ public class RenderApi {
                             @Context HttpServletRequest request,
                             @Context HttpServletResponse response ) throws IOException, ThingWriteException {
 
+    solution = XSSHelper.getInstance().escape( solution );
+    path = XSSHelper.getInstance().escape( path );
+    file = XSSHelper.getInstance().escape( file );
+    root = XSSHelper.getInstance().escape( root );
+    scheme = XSSHelper.getInstance().escape( scheme );
+
     String schemeToUse = "";
     if ( !inferScheme ) {
       schemeToUse = StringUtils.isEmpty( scheme ) ? request.getScheme() : scheme;
@@ -127,6 +133,12 @@ public class RenderApi {
                             @QueryParam( MethodParams.SCHEME ) @DefaultValue( "" ) String scheme,
                             @Context HttpServletRequest request,
                             @Context HttpServletResponse response ) throws IOException, ThingWriteException {
+
+    solution = XSSHelper.getInstance().escape( solution );
+    path = XSSHelper.getInstance().escape( path );
+    file = XSSHelper.getInstance().escape( file );
+    root = XSSHelper.getInstance().escape( root );
+    scheme = XSSHelper.getInstance().escape( scheme );
 
     String schemeToUse = "";
     if ( !inferScheme ) {
@@ -154,6 +166,15 @@ public class RenderApi {
                         @QueryParam( MethodParams.VIEW ) @DefaultValue( "" ) String view,
                         @QueryParam( MethodParams.STYLE ) @DefaultValue( "" ) String style,
                         @Context HttpServletRequest request ) throws IOException {
+
+    solution = XSSHelper.getInstance().escape( solution );
+    path = XSSHelper.getInstance().escape( path );
+    file = XSSHelper.getInstance().escape( file );
+    root = XSSHelper.getInstance().escape( root );
+    scheme = XSSHelper.getInstance().escape( scheme );
+    view = XSSHelper.getInstance().escape( view );
+    style = XSSHelper.getInstance().escape( style );
+
     String schemeToUse = "";
     if ( !inferScheme ) {
       schemeToUse = StringUtils.isEmpty( scheme ) ? request.getScheme() : scheme;
@@ -235,6 +256,15 @@ public class RenderApi {
                               @QueryParam( MethodParams.STYLE ) @DefaultValue( "" ) String style,
                               @QueryParam( MethodParams.ALIAS ) @DefaultValue( "" ) String alias,
                               @Context HttpServletRequest request ) throws IOException {
+
+
+    path = XSSHelper.getInstance().escape( path );
+    root = XSSHelper.getInstance().escape( root );
+    scheme = XSSHelper.getInstance().escape( scheme );
+    view = XSSHelper.getInstance().escape( view );
+    style = XSSHelper.getInstance().escape( style );
+    alias = XSSHelper.getInstance().escape( alias );
+
     final String schemeToUse;
     if ( !inferScheme ) {
       schemeToUse = StringUtils.isEmpty( scheme ) ? request.getScheme() : scheme;
@@ -306,6 +336,9 @@ public class RenderApi {
     @Context HttpServletRequest servletRequest,
     @Context HttpServletResponse servletResponse ) throws IOException {
 
+
+    path = XSSHelper.getInstance().escape( path );
+
     servletResponse.setContentType( APPLICATION_JSON );
     servletResponse.setCharacterEncoding( CharsetHelper.getEncoding() );
     setCorsHeaders( servletRequest, servletResponse );
@@ -337,6 +370,8 @@ public class RenderApi {
     @QueryParam( MethodParams.BYPASSCACHE ) @DefaultValue( "false" ) boolean bypassCache,
     @Context HttpServletRequest servletRequest,
     @Context HttpServletResponse servletResponse ) throws IOException, JSONException {
+
+    path = XSSHelper.getInstance().escape( path );
 
     servletResponse.setContentType( APPLICATION_JSON );
     servletResponse.setCharacterEncoding( CharsetHelper.getEncoding() );
@@ -373,6 +408,10 @@ public class RenderApi {
     @Context HttpServletRequest request,
     @Context HttpServletResponse response ) throws Exception {
 
+    solution = XSSHelper.getInstance().escape( solution );
+    path = XSSHelper.getInstance().escape( path );
+    file = XSSHelper.getInstance().escape( file );
+
     String wcdfPath = getWcdfRelativePath( solution, path, file );
 
     if ( !CdeEnvironment.canCreateContent() ) {
@@ -401,6 +440,8 @@ public class RenderApi {
                               @QueryParam( "isDefault" ) @DefaultValue( "false" ) boolean isDefault,
                               @Context HttpServletRequest request,
                               @Context HttpServletResponse response ) throws Exception {
+
+    path = XSSHelper.getInstance().escape( path );
 
     if ( !CdeEnvironment.canCreateContent() ) {
       return "This functionality is limited to users with permission 'Create Content'";

--- a/cde-pentaho5/src/pt/webdetails/cdf/dd/api/ResourcesApi.java
+++ b/cde-pentaho5/src/pt/webdetails/cdf/dd/api/ResourcesApi.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ * Copyright 2002 - 2017 Webdetails, a Pentaho company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -76,6 +76,9 @@ public class ResourcesApi {
   @Produces( TEXT_PLAIN )
   public void getResource( @QueryParam( "resource" ) @DefaultValue( "" ) String resource,
                            @Context HttpServletResponse response ) throws IOException {
+
+    resource = XSSHelper.getInstance().escape( resource );
+
     try {
       String extension = resource.replaceAll( ".*\\.(.*)", "$1" );
       if ( allowedExtensions.indexOf( extension ) < 0 ) {
@@ -123,6 +126,10 @@ public class ResourcesApi {
                               @QueryParam( "resource" ) @DefaultValue( "" ) String resource,
                               @Context HttpServletResponse response )
     throws IOException {
+
+    path = XSSHelper.getInstance().escape( path );
+    resource = XSSHelper.getInstance().escape( resource );
+
     getResource( resource, response );
   }
 
@@ -133,6 +140,10 @@ public class ResourcesApi {
                              @QueryParam( "resource" ) @DefaultValue( "" ) String resource,
                              @Context HttpServletResponse response )
     throws IOException {
+
+    path = XSSHelper.getInstance().escape( path );
+    resource = XSSHelper.getInstance().escape( resource );
+
     getResource( resource, response );
   }
 
@@ -143,6 +154,10 @@ public class ResourcesApi {
                                   @QueryParam( "resource" ) @DefaultValue( "" ) String resource,
                                   @Context HttpServletResponse response )
     throws IOException {
+
+    path = XSSHelper.getInstance().escape( path );
+    resource = XSSHelper.getInstance().escape( resource );
+
     response.setHeader( "content-disposition", "inline" );
 
     getResource( resource, response );
@@ -155,6 +170,10 @@ public class ResourcesApi {
                         @QueryParam( "resource" ) @DefaultValue( "" ) String resource,
                         @Context HttpServletResponse response )
     throws IOException {
+
+    path = XSSHelper.getInstance().escape( path );
+    resource = XSSHelper.getInstance().escape( resource );
+
     getResource( resource, response );
   }
 
@@ -165,6 +184,10 @@ public class ResourcesApi {
                    @QueryParam( "resource" ) @DefaultValue( "" ) String resource,
                    @Context HttpServletResponse response )
     throws Exception {
+
+    path = XSSHelper.getInstance().escape( path );
+    resource = XSSHelper.getInstance().escape( resource );
+
     getResource( resource, response );
   }
 
@@ -178,6 +201,12 @@ public class ResourcesApi {
                                @QueryParam( "access" ) String access,
                                @QueryParam( "showHiddenFiles" ) @DefaultValue( "false" ) boolean showHiddenFiles )
     throws IOException {
+
+    folder = XSSHelper.getInstance().escape( folder );
+    outputType = XSSHelper.getInstance().escape( outputType );
+    dashboardPath = XSSHelper.getInstance().escape( dashboardPath );
+    fileExtensions = XSSHelper.getInstance().escape( fileExtensions );
+    access = XSSHelper.getInstance().escape( access );
 
     if ( !StringUtils.isEmpty( outputType ) && outputType.equals( "json" ) ) {
       try {
@@ -261,6 +290,8 @@ public class ResourcesApi {
   public Response getSystemResource( @PathParam( "path" ) String path, @Context HttpServletResponse response )
     throws IOException {
 
+    path = XSSHelper.getInstance().escape( path );
+
     String extension = path.replaceAll( ".*\\.(.*)", "$1" );
     if ( allowedExtensions.indexOf( extension ) < 0 ) {
       // We can't provide this type of file
@@ -295,6 +326,9 @@ public class ResourcesApi {
   @Produces( { WILDCARD } )
   public void resource( @PathParam( "resource" ) String resource, @Context HttpServletResponse response )
     throws Exception {
+
+    resource = XSSHelper.getInstance().escape( resource );
+
     getResource( resource, response );
   }
 

--- a/cde-pentaho5/src/pt/webdetails/cdf/dd/api/SyncronizerApi.java
+++ b/cde-pentaho5/src/pt/webdetails/cdf/dd/api/SyncronizerApi.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ * Copyright 2002 - 2017 Webdetails, a Pentaho company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -85,6 +85,22 @@ public class SyncronizerApi { //TODO: synchronizer?
                             @FormParam( MethodParams.REQUIRE ) boolean require,
                             @Context HttpServletRequest servletRequest,
                             @Context HttpServletResponse servletResponse ) throws Exception {
+
+    file = XSSHelper.getInstance().escape( file );
+    path = XSSHelper.getInstance().escape( path );
+    author = XSSHelper.getInstance().escape( author );
+    description = XSSHelper.getInstance().escape( description );
+    style = XSSHelper.getInstance().escape( style );
+    widgetName = XSSHelper.getInstance().escape( widgetName );
+    rendererType = XSSHelper.getInstance().escape( rendererType );
+    cdfStructure = XSSHelper.getInstance().escape( cdfStructure );
+    operation = XSSHelper.getInstance().escape( operation );
+    if ( null != widgetParams ) {
+      for ( int i = 0; i < widgetParams.size(); i++ ) {
+        widgetParams.add( i, XSSHelper.getInstance().escape( widgetParams.get( i ) ) );
+      }
+    }
+
 
     servletResponse.setContentType( APPLICATION_JSON );
     servletResponse.setCharacterEncoding( CharsetHelper.getEncoding() );
@@ -191,6 +207,11 @@ public class SyncronizerApi { //TODO: synchronizer?
       @FormParam( MethodParams.RENDERER_TYPE ) String rendererType,
       @Context HttpServletResponse servletResponse ) throws IOException, DashboardStructureException, JSONException {
 
+    file = XSSHelper.getInstance().escape( file );
+    rendererType = XSSHelper.getInstance().escape( rendererType );
+    cdfStructure = XSSHelper.getInstance().escape( cdfStructure );
+    operation = XSSHelper.getInstance().escape( operation );
+
     servletResponse.setContentType( APPLICATION_JSON );
     servletResponse.setCharacterEncoding( CharsetHelper.getEncoding() );
 
@@ -242,6 +263,12 @@ public class SyncronizerApi { //TODO: synchronizer?
                                @FormDataParam( MethodParams.DASHBOARD_STRUCTURE ) String cdfStructure,
                                @FormDataParam( MethodParams.OPERATION ) String operation,
                                @Context HttpServletResponse response ) throws Exception {
+
+    file = XSSHelper.getInstance().escape( file );
+    title = XSSHelper.getInstance().escape( title );
+    description = XSSHelper.getInstance().escape( description );
+    cdfStructure = XSSHelper.getInstance().escape( cdfStructure );
+    operation = XSSHelper.getInstance().escape( operation );
 
     response.setContentType( APPLICATION_JSON );
     response.setCharacterEncoding( CharsetHelper.getEncoding() );

--- a/cde-pentaho5/src/pt/webdetails/cdf/dd/api/XSSHelper.java
+++ b/cde-pentaho5/src/pt/webdetails/cdf/dd/api/XSSHelper.java
@@ -1,0 +1,39 @@
+/*!
+ * Copyright 2002 - 2017 Webdetails, a Pentaho company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+
+package pt.webdetails.cdf.dd.api;
+
+import org.pentaho.platform.util.StringUtil;
+import org.pentaho.platform.web.http.api.resources.utils.EscapeUtils;
+
+public class XSSHelper {
+
+  private static XSSHelper instance = new XSSHelper();
+
+  public static XSSHelper getInstance() {
+    return instance;
+  }
+
+
+  static void setInstance( final XSSHelper newInstance ) {
+    instance = newInstance;
+  }
+
+  public String escape( final String userInput ) {
+    if ( StringUtil.isEmpty( userInput ) ) {
+      return userInput;
+    }
+    return EscapeUtils.escapeJsonOrRaw( userInput );
+  }
+
+}

--- a/cde-pentaho5/test-src/pt/webdetails/cdf/dd/api/EditorApiTest.java
+++ b/cde-pentaho5/test-src/pt/webdetails/cdf/dd/api/EditorApiTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2015 Webdetails, a Pentaho company. All rights reserved.
+ * Copyright 2002 - 2017 Webdetails, a Pentaho company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -14,20 +14,52 @@
 package pt.webdetails.cdf.dd.api;
 
 import junit.framework.Assert;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
 
 public class EditorApiTest {
 
   private static EditorApiForTesting editorApi;
   private final String FAKE_PATH = "/fake/path/";
   private final String FAKE_FILE = "fakeFile.css";
+  private static XSSHelper originalHelper;
+  private static XSSHelper mockHelper;
 
   @BeforeClass
-  public static void setUp() throws Exception {
+  public static void setUp() {
+    originalHelper = XSSHelper.getInstance();
+  }
+
+  @Before
+  public void beforeEach() throws Exception {
     editorApi = new EditorApiForTesting();
+    mockHelper = mock( XSSHelper.class );
+    when( mockHelper.escape( any() ) ).thenAnswer( new Answer<Object>() {
+      @Override public Object answer( InvocationOnMock invocation ) throws Throwable {
+        return invocation.getArguments()[ 0 ];
+      }
+    } );
+    XSSHelper.setInstance( mockHelper );
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    XSSHelper.setInstance( originalHelper );
+  }
+
+  @After
+  public void afterEach() {
+    reset( mockHelper );
   }
 
   @Test
@@ -59,6 +91,7 @@ public class EditorApiTest {
     Assert.assertEquals( MESSAGE_ERROR, hasAccessSaveFalse );
     Assert.assertEquals( MESSAGE_NO_PERMISSIONS, noAccessSaveTrue );
     Assert.assertEquals( MESSAGE_NO_PERMISSIONS, noAccessSaveFalse );
+    verify( mockHelper, atLeastOnce() ).escape( anyString() );
   }
 
 }

--- a/cde-pentaho5/test-src/pt/webdetails/cdf/dd/api/SynchronizerApiTest.java
+++ b/cde-pentaho5/test-src/pt/webdetails/cdf/dd/api/SynchronizerApiTest.java
@@ -13,28 +13,34 @@
 
 package pt.webdetails.cdf.dd.api;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.mockito.Mockito.spy;
+import junit.framework.Assert;
+import org.apache.commons.lang.StringUtils;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import pt.webdetails.cpf.messaging.MockHttpServletRequest;
+import pt.webdetails.cpf.messaging.MockHttpServletResponse;
+import pt.webdetails.cpf.utils.CharsetHelper;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-import junit.framework.Assert;
-import org.apache.commons.lang.StringUtils;
-import org.json.JSONObject;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-import pt.webdetails.cpf.messaging.MockHttpServletRequest;
-import pt.webdetails.cpf.messaging.MockHttpServletResponse;
-import pt.webdetails.cpf.utils.CharsetHelper;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
 
 public class SynchronizerApiTest {
 
@@ -55,9 +61,21 @@ public class SynchronizerApiTest {
   private static final List<String> widgetParams = new ArrayList<String>();
   private static final String cdfStructure = "MOCK_CDF_STRUCTURE";
   private String operation = "savesettings";
+  private static XSSHelper originalHelper;
+  private static XSSHelper mockHelper;
+
+  @BeforeClass
+  public static void setUp() {
+    originalHelper = XSSHelper.getInstance();
+  }
+
+  @AfterClass
+  public static void afterAll() {
+    XSSHelper.setInstance( originalHelper );
+  }
 
   @Before
-  public void setUp() throws Exception {
+  public void beforeEach() throws Exception {
     synchronizerApi = spy( new SynchronizerApiForTesting() );
     servletRequest = new MockHttpServletRequest( "/pentaho-cdf/api/views", (Map) new HashMap<String, String[]>() );
     servletResponse = new MockHttpServletResponse( new ObjectOutputStream( new ByteArrayOutputStream() ) );
@@ -65,6 +83,13 @@ public class SynchronizerApiTest {
     servletResponse.setCharacterEncoding( null );
     path = StringUtils.EMPTY;
     file = StringUtils.EMPTY;
+    mockHelper = mock( XSSHelper.class );
+    when( mockHelper.escape( any() ) ).thenAnswer( new Answer<Object>() {
+      @Override public Object answer( InvocationOnMock invocation ) throws Throwable {
+        return invocation.getArguments()[ 0 ];
+      }
+    } );
+    XSSHelper.setInstance( mockHelper );
   }
 
   @After
@@ -74,6 +99,7 @@ public class SynchronizerApiTest {
     servletResponse = null;
     file = null;
     path = null;
+    reset( mockHelper );
   }
 
   @Test
@@ -96,6 +122,7 @@ public class SynchronizerApiTest {
     Assert.assertTrue( jsonObj.getString( "result" ) != null );
     Assert.assertTrue( "false".equals( jsonObj.getString( "status" ) ) );
     Assert.assertTrue( "CdfTemplates.ERROR_003_SAVE_DASHBOARD_FIRST".equals( jsonObj.getString( "result" ) ) );
+    verify( mockHelper, atLeastOnce() ).escape( anyString() );
   }
 
   @Test
@@ -108,6 +135,7 @@ public class SynchronizerApiTest {
 
     Assert.assertTrue( servletResponse.getContentType().equals( APPLICATION_JSON ) );
     Assert.assertTrue( servletResponse.getCharacterEncoding().equals( CharsetHelper.getEncoding() ) );
+    verify( mockHelper, atLeastOnce() ).escape( anyString() );
   }
 
   @Test
@@ -120,6 +148,7 @@ public class SynchronizerApiTest {
 
     Assert.assertTrue( servletResponse.getContentType().equals( APPLICATION_JSON ) );
     Assert.assertTrue( servletResponse.getCharacterEncoding().equals( CharsetHelper.getEncoding() ) );
+    verify( mockHelper, atLeastOnce() ).escape( anyString() );
   }
 
   @Test
@@ -144,5 +173,6 @@ public class SynchronizerApiTest {
 
     Assert.assertTrue( servletResponse.getContentType().equals( APPLICATION_JSON ) );
     Assert.assertTrue( servletResponse.getCharacterEncoding().equals( CharsetHelper.getEncoding() ) );
+    verify( mockHelper, atLeastOnce() ).escape( anyString() );
   }
 }

--- a/cde-pentaho5/test-src/pt/webdetails/cdf/dd/api/XSSHelperTest.java
+++ b/cde-pentaho5/test-src/pt/webdetails/cdf/dd/api/XSSHelperTest.java
@@ -1,0 +1,41 @@
+/*!
+ * Copyright 2002 - 2017 Webdetails, a Pentaho company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+
+
+package pt.webdetails.cdf.dd.api;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class XSSHelperTest {
+
+  private final String XSS = "<html><script>alert(1);</script></html>";
+
+  @Test
+  public void escape() throws Exception {
+    assertFalse( XSS.equals( XSSHelper.getInstance().escape( XSS ) ) );
+  }
+
+  @Test
+  public void escapeEmpty() throws Exception {
+    assertEquals( "", XSSHelper.getInstance().escape( "" ) );
+  }
+
+  @Test
+  public void escapeNull() throws Exception {
+    assertEquals( null, XSSHelper.getInstance().escape( null ) );
+  }
+
+}


### PR DESCRIPTION
HTML and WILDCARD content-types are obviously affected, but not only them. I've learned that there is an attack wich can also affect other content types, so I've added escaping to few more endpoints. 
plus unit tests. One test is failing with a fix and without it locally, but seems to be OK in other PRs, so may be a local issue.