### PR TITLE
[BACKLOG-15020] New CCC chart, Sunburst color mode, `level`.

### DIFF
--- a/cde-core/resource/resources/base/properties/cccColorMode.xml
+++ b/cde-core/resource/resources/base/properties/cccColorMode.xml
@@ -15,6 +15,7 @@
     <Value display="By-Parent">byParent</Value>
     <Value display="By-Self">bySelf</Value>
     <Value display="Fan">fan</Value>
+    <Value display="Level">level</Value>
     <Value display="Slice">slice</Value>
   </Values>
 </DesignerProperty>


### PR DESCRIPTION

@davidmsantos90, @carlosrusso, @nantunes please review.

Depends on: https://github.com/webdetails/ccc/pull/278.