### PR TITLE
[PDB-1987] Check box filters with no default value set, display the first checkbox as selected

### DIFF
--- a/cde-core/resource/resources/base/components/Checkbox.xml
+++ b/cde-core/resource/resources/base/components/Checkbox.xml
@@ -19,6 +19,7 @@
       </Definition>
       <Property>postFetch</Property>
       <Property>valuesArray</Property>
+      <Property>useFirstValue</Property>
       <Property>valueAsId</Property>
       <Property>separator</Property>
       <Property>executeAtStart</Property>

--- a/cde-core/resource/resources/base/components/Select.xml
+++ b/cde-core/resource/resources/base/components/Select.xml
@@ -19,6 +19,7 @@
       </Definition>
       <Property>postFetch</Property>
       <Property>valuesArray</Property>
+      <Property>useFirstValue</Property>
       <Property>valueAsId</Property>
       <Property>externalPlugin</Property>
       <Property>executeAtStart</Property>

--- a/cde-core/resource/resources/base/components/SelectMulti.xml
+++ b/cde-core/resource/resources/base/components/SelectMulti.xml
@@ -19,6 +19,7 @@
       </Definition>
       <Property>postFetch</Property>
       <Property>valuesArray</Property>
+      <Property>useFirstValue</Property>
       <Property>valueAsId</Property>
       <Property>size</Property>
       <Property>externalPlugin</Property>

--- a/cde-core/resource/resources/base/properties/UseFirstValue.xml
+++ b/cde-core/resource/resources/base/properties/UseFirstValue.xml
@@ -1,9 +1,9 @@
 <DesignerProperty>
   <Header>
-    <Name>defaultIfEmpty</Name>
+    <Name>useFirstValue</Name>
     <Parent>BaseProperty</Parent>
-    <DefaultValue>"false"</DefaultValue>
-    <Description>Default If Empty</Description>
+    <DefaultValue>"true"</DefaultValue>
+    <Description>Use first value</Description>
     <Tooltip>If true, the first possible value is selected, otherwise, nothing is selected</Tooltip>
     <InputType>Boolean</InputType>
     <OutputType>Boolean</OutputType>


### PR DESCRIPTION
  - renamed the component property that controls first value selection, from `defaultIfEmpty` to `useFirstValue`, to be consistent with dashboards and common-ui plugins across the platform
  - made `useFirstValue` available in the CDE editor advanced properties panel for the respective CDF base components. Radio and MultiButton not included because they don’t seem to support the `false` value and always default to the first available value.