### PR TITLE
[BACKLOG-20079] Include individual RequireJS config files in the build artifacts for pentaho platform

### DIFF
--- a/assemblies/platform/pentaho-cdf-dd/src/assembly/assembly.xml
+++ b/assemblies/platform/pentaho-cdf-dd/src/assembly/assembly.xml
@@ -37,14 +37,15 @@
       <directory>${basedir}/target/dependency/cde/amd-components-compressed</directory>
       <outputDirectory>pentaho-cdf-dd/resources/custom/amd-components-compressed</outputDirectory>
     </fileSet>
+    <!-- AMD Custom Components RequireJS configuration files -->
+    <fileSet>
+      <directory>${basedir}/target/dependency/cde</directory>
+      <outputDirectory>pentaho-cdf-dd/js</outputDirectory>
+      <includes>
+        <include>${requirejs.config.files.pattern}</include>
+      </includes>
+    </fileSet>
   </fileSets>
-  <!-- AMD Custom Components RequireJS configuration file -->
-  <files>
-    <file>
-      <source>${basedir}/target/dependency/cde/${global.require.file}</source>
-      <destName>pentaho-cdf-dd/js/${global.require.file}</destName>
-    </file>
-  </files>
 
   <dependencySets>
     <dependencySet>

--- a/components/amd/assemblies/cde-components-amd-platform/pom.xml
+++ b/components/amd/assemblies/cde-components-amd-platform/pom.xml
@@ -60,7 +60,7 @@
               <target>
                 <concat destfile="${project.build.directory}/${global.require.file}" force="yes" append="true">
                   <fileset casesensitive="yes" dir="${basedir}/target/dependency/cde">
-                    <include name="${requirejs.config.files.pattern}" />
+                    <include name="${requirejs.config.files.pattern}"/>
                   </fileset>
                 </concat>
               </target>

--- a/components/amd/assemblies/cde-components-amd-platform/src/assembly/assembly.xml
+++ b/components/amd/assemblies/cde-components-amd-platform/src/assembly/assembly.xml
@@ -14,8 +14,14 @@
       <destName>cde/${global.require.file}</destName>
     </file>
   </files>
-
   <fileSets>
+    <fileSet>
+      <directory>${basedir}/target/dependency/cde</directory>
+      <outputDirectory>cde</outputDirectory>
+      <includes>
+        <include>${requirejs.config.files.pattern}</include>
+      </includes>
+    </fileSet>
     <fileSet>
       <directory>${basedir}/target/dependency/cde/amd-components</directory>
       <outputDirectory>cde/amd-components</outputDirectory>


### PR DESCRIPTION
@diogofscmariano @hbfernandes  @pamval please review.
Although we have a global requireJS config file, for legacy reasons, the plugin.xml cannot be changed so we still need to include the individual files in the built artifacts.