### PR TITLE
[BACKLOG-20079] Mavenize the CDE plugin

### DIFF
--- a/assemblies/platform/pentaho-cdf-dd-disabled/src/main/resources/plugin.xml.disabled
+++ b/assemblies/platform/pentaho-cdf-dd-disabled/src/main/resources/plugin.xml.disabled
@@ -1,54 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin title="pentaho-cdf-dd">
-	<lifecycle-listener class="pt.webdetails.cdf.dd.CdeLifeCycleListener"/>
-	<static-paths>
-		<static-path url="/pentaho-cdf-dd/js" localFolder="js"/>
-		<static-path url="/pentaho-cdf-dd/css" localFolder="css"/>
-		<static-path url="/pentaho-cdf-dd/images" localFolder="images"/>
-		<static-path url="/pentaho-cdf-dd/lang" localFolder="lang"/>
-		<static-path url="/pentaho-cdf-dd/static" localFolder="static"/>
-        <static-path url="/pentaho-cdf-dd/resources" localFolder="resources"/>
-        <static-path url="/pentaho-cdf-dd/tmp" localFolder="tmp"/>
-	</static-paths>
-	<content-types>
-		<content-type type="wcdf" mime-type="text/html">
-			<title>Dashboard Designer</title>
-			<description>Dashboard Designer</description>
-			<icon-url>plugin/pentaho-cdf-dd/api/resources/get?resource=/resources/wcdfFileType.png</icon-url>
-            <operations>
-    <!--              
-                <operation>
-                    <id>EDIT</id>
-                    <perspective>wcdf.edit</perspective>
-                </operation>
-    -->
-                <operation>
-                    <id>RUN</id>
-                </operation>
-                <operation>
-                    <id>NEWWINDOW</id>
-                </operation>
-            </operations>
-		</content-type>
-	</content-types>
-
-
-    <!--
-    <overlays>
-        <overlay id="launch" resourcebundle="content/pentaho-cdf-dd/lang/messages">
-            <button id="launch_new_cde" label="${Launcher.CDE}" command="Home.openFile('${Launcher.CDE}', '${Launcher.CDE_TOOLTIP}', 'api/repos/wcdf/new');$('#btnCreateNew').popover('hide');"/>
-        </overlay>
-        <overlay id="startup.cde_dashboard"  resourcebundle="content/pentaho-cdf-dd/lang/messages" priority="1">
-            <menubar id="newmenu">
-                <menuitem id="new-cde_dashboard" label="${Launcher.CDE}" command="mantleXulHandler.openUrl('${Launcher.CDE}','${Launcher.CDE_TOOLTIP}','api/repos/wcdf/new')" />
-            </menubar>
-        </overlay>
-	</overlays>
-    -->
-
-    <external-resources>
-        <file context="requirejs">content/pentaho-cdf-dd/js/cde-core-require-js-cfg.js</file>
-        <file context="requirejs">content/pentaho-cdf-dd/js/cde-pentaho-require-js-cfg.js</file>
-    </external-resources>
-
+  <lifecycle-listener class="pt.webdetails.cdf.dd.CdeLifeCycleListener"/>
+  <static-paths>
+    <static-path url="/pentaho-cdf-dd/js" localFolder="js"/>
+    <static-path url="/pentaho-cdf-dd/css" localFolder="css"/>
+    <static-path url="/pentaho-cdf-dd/images" localFolder="images"/>
+    <static-path url="/pentaho-cdf-dd/lang" localFolder="lang"/>
+    <static-path url="/pentaho-cdf-dd/static" localFolder="static"/>
+    <static-path url="/pentaho-cdf-dd/resources" localFolder="resources"/>
+    <static-path url="/pentaho-cdf-dd/tmp" localFolder="tmp"/>
+  </static-paths>
+  <content-types>
+    <content-type type="wcdf" mime-type="text/html">
+      <title>Dashboard Designer</title>
+      <description>Dashboard Designer</description>
+      <icon-url>plugin/pentaho-cdf-dd/api/resources/get?resource=/resources/wcdfFileType.png</icon-url>
+      <operations>
+        <!--              
+        <operation>
+          <id>EDIT</id>
+          <perspective>wcdf.edit</perspective>
+        </operation>
+        -->
+        <operation>
+          <id>RUN</id>
+        </operation>
+        <operation>
+          <id>NEWWINDOW</id>
+        </operation>
+      </operations>
+    </content-type>
+  </content-types>
+  <!--
+  <overlays>
+    <overlay id="launch" resourcebundle="content/pentaho-cdf-dd/lang/messages">
+      <button id="launch_new_cde" label="${Launcher.CDE}" command="Home.openFile('${Launcher.CDE}', '${Launcher.CDE_TOOLTIP}', 'api/repos/wcdf/new');$('#btnCreateNew').popover('hide');"/>
+    </overlay>
+    <overlay id="startup.cde_dashboard"  resourcebundle="content/pentaho-cdf-dd/lang/messages" priority="1">
+      <menubar id="newmenu">
+        <menuitem id="new-cde_dashboard" label="${Launcher.CDE}" command="mantleXulHandler.openUrl('${Launcher.CDE}','${Launcher.CDE_TOOLTIP}','api/repos/wcdf/new')" />
+      </menubar>
+    </overlay>
+  </overlays>
+  -->
+  <external-resources>
+    <file context="requirejs">content/pentaho-cdf-dd/js/cde-require-js-cfg.js</file>
+  </external-resources>
 </plugin>

--- a/assemblies/platform/pentaho-cdf-dd-disabled/src/main/resources/settings.xml.disabled
+++ b/assemblies/platform/pentaho-cdf-dd-disabled/src/main/resources/settings.xml.disabled
@@ -46,4 +46,8 @@
    -->
   <allow-cross-domain-resources>false</allow-cross-domain-resources>
 
+  <!-- A comma separated list of allowed domains for a cross-origin resource sharing-->
+  <cross-domain-resources-whitelist><!--intentionally left blank --></cross-domain-resources-whitelist>
+  <!-- A flag to disable reflected XSS prevention for the unpredicted cases -->
+  <parameter-xss-escaping>true</parameter-xss-escaping>
 </settings>

--- a/assemblies/platform/pentaho-cdf-dd/src/assembly/assembly.xml
+++ b/assemblies/platform/pentaho-cdf-dd/src/assembly/assembly.xml
@@ -37,15 +37,15 @@
       <directory>${basedir}/target/dependency/cde/amd-components-compressed</directory>
       <outputDirectory>pentaho-cdf-dd/resources/custom/amd-components-compressed</outputDirectory>
     </fileSet>
-    <!-- AMD Custom Components RequireJS configuration files -->
-    <fileSet>
-      <directory>${basedir}/target/dependency/cde</directory>
-      <outputDirectory>pentaho-cdf-dd/js</outputDirectory>
-      <includes>
-        <include>${requirejs.config.files.pattern}</include>
-      </includes>
-    </fileSet>
   </fileSets>
+
+  <!-- AMD Custom Components RequireJS configuration file -->
+  <files>
+    <file>
+      <source>${basedir}/target/dependency/cde/${global.require.file}</source>
+      <destName>pentaho-cdf-dd/js/${global.require.file}</destName>
+    </file>
+  </files>
 
   <dependencySets>
     <dependencySet>

--- a/assemblies/platform/pentaho-cdf-dd/src/main/resources/plugin.xml
+++ b/assemblies/platform/pentaho-cdf-dd/src/main/resources/plugin.xml
@@ -1,47 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin title="pentaho-cdf-dd">
-	<lifecycle-listener class="pt.webdetails.cdf.dd.CdeLifeCycleListener"/>
-	<static-paths>
-		<static-path url="/pentaho-cdf-dd/js" localFolder="js"/>
-		<static-path url="/pentaho-cdf-dd/css" localFolder="css"/>
-		<static-path url="/pentaho-cdf-dd/images" localFolder="images"/>
-		<static-path url="/pentaho-cdf-dd/lang" localFolder="lang"/>
-		<static-path url="/pentaho-cdf-dd/static" localFolder="static"/>
-        <static-path url="/pentaho-cdf-dd/resources" localFolder="resources"/>
-        <static-path url="/pentaho-cdf-dd/tmp" localFolder="tmp"/>
-	</static-paths>
-	<content-types>
-		<content-type type="wcdf" mime-type="text/html">
-			<title>Dashboard Designer</title>
-			<description>Dashboard Designer</description>
-			<icon-url>plugin/pentaho-cdf-dd/api/resources/get?resource=/resources/wcdfFileType.png</icon-url>
-            <operations>
-                <operation>
-                    <id>EDIT</id>
-                    <perspective>wcdf.edit</perspective>
-                </operation>
-                <operation>
-                    <id>RUN</id>
-                </operation>
-                <operation>
-                    <id>NEWWINDOW</id>
-                </operation>
-            </operations>
-		</content-type>
-	</content-types>
-	<overlays>
-        <overlay id="launch" resourcebundle="content/pentaho-cdf-dd/lang/messages">
-            <button id="launch_new_cde" label="${Launcher.CDE}" command="Home.openFile('${Launcher.CDE}', '${Launcher.CDE_TOOLTIP}', 'api/repos/wcdf/new');$('#btnCreateNew').popover('hide');"/>
-        </overlay>
-        <overlay id="startup.cde_dashboard"  resourcebundle="content/pentaho-cdf-dd/lang/messages" priority="1">
-            <menubar id="newmenu">
-                <menuitem id="new-cde_dashboard" label="${Launcher.CDE}" command="mantleXulHandler.openUrl('${Launcher.CDE}','${Launcher.CDE_TOOLTIP}','api/repos/wcdf/new')" />
-            </menubar>
-        </overlay>
-	</overlays>
-
-    <external-resources>
-        <file context="requirejs">content/pentaho-cdf-dd/js/cde-require-js-cfg.js</file>
-    </external-resources>
-
+  <lifecycle-listener class="pt.webdetails.cdf.dd.CdeLifeCycleListener"/>
+  <static-paths>
+    <static-path url="/pentaho-cdf-dd/js" localFolder="js"/>
+    <static-path url="/pentaho-cdf-dd/css" localFolder="css"/>
+    <static-path url="/pentaho-cdf-dd/images" localFolder="images"/>
+    <static-path url="/pentaho-cdf-dd/lang" localFolder="lang"/>
+    <static-path url="/pentaho-cdf-dd/static" localFolder="static"/>
+    <static-path url="/pentaho-cdf-dd/resources" localFolder="resources"/>
+    <static-path url="/pentaho-cdf-dd/tmp" localFolder="tmp"/>
+  </static-paths>
+  <content-types>
+    <content-type type="wcdf" mime-type="text/html">
+      <title>Dashboard Designer</title>
+      <description>Dashboard Designer</description>
+      <icon-url>plugin/pentaho-cdf-dd/api/resources/get?resource=/resources/wcdfFileType.png</icon-url>
+      <operations>
+        <operation>
+          <id>EDIT</id>
+          <perspective>wcdf.edit</perspective>
+        </operation>
+        <operation>
+          <id>RUN</id>
+        </operation>
+        <operation>
+          <id>NEWWINDOW</id>
+        </operation>
+      </operations>
+    </content-type>
+  </content-types>
+  <overlays>
+    <overlay id="launch" resourcebundle="content/pentaho-cdf-dd/lang/messages">
+      <button id="launch_new_cde" label="${Launcher.CDE}" command="Home.openFile('${Launcher.CDE}', '${Launcher.CDE_TOOLTIP}', 'api/repos/wcdf/new');$('#btnCreateNew').popover('hide');"/>
+    </overlay>
+    <overlay id="startup.cde_dashboard"  resourcebundle="content/pentaho-cdf-dd/lang/messages" priority="1">
+      <menubar id="newmenu">
+        <menuitem id="new-cde_dashboard" label="${Launcher.CDE}" command="mantleXulHandler.openUrl('${Launcher.CDE}','${Launcher.CDE_TOOLTIP}','api/repos/wcdf/new')" />
+      </menubar>
+    </overlay>
+  </overlays>
+  <external-resources>
+    <file context="requirejs">content/pentaho-cdf-dd/js/cde-require-js-cfg.js</file>
+  </external-resources>
 </plugin>

--- a/components/amd/assemblies/cde-components-amd-platform/src/assembly/assembly.xml
+++ b/components/amd/assemblies/cde-components-amd-platform/src/assembly/assembly.xml
@@ -8,24 +8,21 @@
 
   <includeBaseDirectory>false</includeBaseDirectory>
 
+  <!-- AMD Custom Components RequireJS configuration file -->
   <files>
     <file>
       <source>${basedir}/target/${global.require.file}</source>
       <destName>cde/${global.require.file}</destName>
     </file>
   </files>
+
   <fileSets>
-    <fileSet>
-      <directory>${basedir}/target/dependency/cde</directory>
-      <outputDirectory>cde</outputDirectory>
-      <includes>
-        <include>${requirejs.config.files.pattern}</include>
-      </includes>
-    </fileSet>
+    <!-- AMD Custom Components -->
     <fileSet>
       <directory>${basedir}/target/dependency/cde/amd-components</directory>
       <outputDirectory>cde/amd-components</outputDirectory>
     </fileSet>
+    <!-- AMD Custom Components Minified -->
     <fileSet>
       <directory>${basedir}/target/build-javascript/cde/amd-components</directory>
       <outputDirectory>cde/amd-components-compressed</outputDirectory>


### PR DESCRIPTION
  - sync Pentaho Platform CE and EE configuration files (plugin.xml and settings.xml)
  - use the same global CDE requireJS configuration file in both CE and EE Pentaho Server assemblies