### PR TITLE
[BACKLOG-20970] - Choose from a list of available dataservice names when creating a dataservice datasource in CDE

### DIFF
--- a/webclient/impls/core/src/test/javascript/cdf-dd-components-others-spec.js
+++ b/webclient/impls/core/src/test/javascript/cdf-dd-components-others-spec.js
@@ -11,11 +11,11 @@
  * the license for the specific language governing your rights and limitations.
  */
 
-fdescribe("CDF-DD-COMPONENTS-OTHERS-TESTS", function () {
+describe("CDF-DD-COMPONENTS-OTHERS-TESTS", function () {
   var tableManager = new TableManager('test-tableManager');
   var dataServiceNameRenderer = new DataServiceNameRenderer();
 
-  fdescribe("Testing DataServiceNameRenderer", function () {
+  describe("Testing DataServiceNameRenderer", function () {
 
     beforeEach(function () {
       dataServicNameRenderer = new DataServiceNameRenderer();


### PR DESCRIPTION
  - re-enable all JS unit tests