### PR TITLE
[BACKLOG-23027] MapComponent sample has broken images for markers

### DIFF
--- a/components/impls/pentaho/src/main/javascript/components/NewMapComponent/amd/Map.ext.js
+++ b/components/impls/pentaho/src/main/javascript/components/NewMapComponent/amd/Map.ext.js
@@ -17,7 +17,7 @@ define([
 
   return {
     getMarkerImgPath: function() {
-      return environment.server.root + 'api/repos/pentaho-cdf-dd/resources/components/Map/amd/images/';
+      return environment.server.root + 'api/repos/pentaho-cdf-dd/resources/components/NewMapComponent/amd/images/';
     }
   };
 


### PR DESCRIPTION
@webdetails/millenniumfalcon please review.

- The path changed when the PDI assembly was created for CDE