### PR TITLE
[BACKLOG-24896] Create pentaho-cdf-dd-rca assembly with remote repository access

### DIFF
--- a/assemblies/platform/pentaho-cdf-dd-rca/pom.xml
+++ b/assemblies/platform/pentaho-cdf-dd-rca/pom.xml
@@ -12,11 +12,6 @@
     <description>Pentaho Community Dashboard Editor Assemblies for the Pentaho Platform Server</description>
     <dependencies>
         <dependency>
-            <groupId>org.pentaho.ctools</groupId>
-            <artifactId>cpf-rca</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>pentaho</groupId>
             <artifactId>cpf-pentaho-rca</artifactId>
             <version>${project.version}</version>

--- a/assemblies/platform/pentaho-cdf-dd-rca/pom.xml
+++ b/assemblies/platform/pentaho-cdf-dd-rca/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.pentaho.ctools</groupId>
+        <artifactId>cde-plugin-assemblies</artifactId>
+        <version>9.0.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>pentaho-cdf-dd-rca</artifactId>
+    <packaging>pom</packaging>
+    <description>Pentaho Community Dashboard Editor Assemblies for the Pentaho Platform Server</description>
+    <dependencies>
+        <dependency>
+            <groupId>org.pentaho.ctools</groupId>
+            <artifactId>cpf-rca</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>pentaho</groupId>
+            <artifactId>cpf-pentaho-rca</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-plugins</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.pentaho.ctools</groupId>
+                                    <artifactId>pentaho-cdf-dd</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>zip</type>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/assemblies/platform/pentaho-cdf-dd-rca/src/assembly/assembly.xml
+++ b/assemblies/platform/pentaho-cdf-dd-rca/src/assembly/assembly.xml
@@ -30,7 +30,6 @@
       <useTransitiveDependencies>false</useTransitiveDependencies>
       <useProjectArtifact>false</useProjectArtifact>
       <includes>
-        <include>org.pentaho.ctools:cpf-rca:jar</include>
         <include>pentaho:cpf-pentaho-rca:jar</include>
       </includes>
     </dependencySet>

--- a/assemblies/platform/pentaho-cdf-dd-rca/src/assembly/assembly.xml
+++ b/assemblies/platform/pentaho-cdf-dd-rca/src/assembly/assembly.xml
@@ -1,0 +1,38 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>pentaho-cdf-dd</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <fileSets>
+    <!-- resources -->
+  <fileSet>
+    <directory>${basedir}/src/main/resources</directory>
+    <outputDirectory>.</outputDirectory>
+  </fileSet>
+
+    <fileSet>
+      <directory>${project.build.directory}/pentaho-cdf-dd</directory>
+      <outputDirectory>.</outputDirectory>
+      <includes>
+        <include>**</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>lib</outputDirectory>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useProjectArtifact>false</useProjectArtifact>
+      <includes>
+        <include>org.pentaho.ctools:cpf-rca:jar</include>
+        <include>pentaho:cpf-pentaho-rca:jar</include>
+      </includes>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/assemblies/platform/pentaho-cdf-dd-rca/src/main/resources/plugin.spring.xml
+++ b/assemblies/platform/pentaho-cdf-dd-rca/src/main/resources/plugin.spring.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ws="http://jax-ws.dev.java.net/spring/core"
+       xmlns:wss="http://jax-ws.dev.java.net/spring/servlet"
+       xmlns:pen="http://www.pentaho.com/schema/pentaho-system"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
+                           http://jax-ws.dev.java.net/spring/core http://jax-ws.dev.java.net/spring/core.xsd
+                           http://jax-ws.dev.java.net/spring/servlet http://jax-ws.dev.java.net/spring/servlet.xsd
+                           http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd">
+
+  <context:annotation-config/>
+  <!-- JAX-RS beans -->
+  <bean id="api" class="org.pentaho.platform.web.servlet.JAXRSPluginServlet"/>
+  <bean id="wcdf" class="pt.webdetails.cdf.dd.DashboardDesignerContentGenerator" scope="prototype">
+    <property name="renderer" ref="renderApi"/>
+    <property name="environment" ref="pentahoCdeEnvironment"/>
+  </bean>
+  <bean id="wcdf.mobile" class="pt.webdetails.cdf.dd.DashboardDesignerContentGenerator" scope="prototype">
+    <property name="renderer" ref="renderApi"/>
+    <property name="environment" ref="pentahoCdeEnvironment"/>
+  </bean>
+  <bean id="datasources" class="pt.webdetails.cdf.dd.api.DatasourcesApi"/>
+  <bean id="wcdf.editor" class="pt.webdetails.cdf.dd.api.EditorApi"/>
+  <bean id="olap" class="pt.webdetails.cpf.olap.OlapApi"/>
+  <bean id="plugins" class="pt.webdetails.cdf.dd.api.PluginsApi"/>
+  <bean id="resourcesapi" class="pt.webdetails.cdf.dd.api.ResourcesApi"/>
+  <bean id="syncronizer" class="pt.webdetails.cdf.dd.api.SyncronizerApi"/>
+  <bean id="version" class="pt.webdetails.cdf.dd.api.VersionApi"/>
+
+  <bean id="wcdf.new" class="pt.webdetails.cdf.dd.DashboardDesignerContentGenerator" scope="prototype">
+    <property name="create" value="true"/>
+    <property name="renderer" ref="renderApi"/>
+    <property name="environment" ref="pentahoCdeEnvironment"/>
+  </bean>
+
+  <bean id="wcdf.edit" class="pt.webdetails.cdf.dd.DashboardDesignerContentGenerator" scope="prototype">
+    <property name="edit" value="true"/>
+    <property name="renderer" ref="renderApi"/>
+    <property name="environment" ref="pentahoCdeEnvironment"/>
+  </bean>
+
+  <bean id="wcdf.res" class="pt.webdetails.cdf.dd.DashboardDesignerContentGenerator" scope="prototype">
+    <property name="resource" value="true"/>
+    <property name="renderer" ref="renderApi"/>
+    <property name="environment" ref="pentahoCdeEnvironment"/>
+  </bean>
+
+  <bean id="cdeEngine" class="pt.webdetails.cdf.dd.CdeEngine" scope="singleton"  factory-method="getInstance">
+    <property name="environment" ref="pentahoCdeEnvironment"/>
+  </bean>
+  <bean id="remoteRepositoryFactory" class="pt.webdetails.cpf.repository.rca.RemoteRepositoryAccessFactory"/>
+  <bean id="pentahoCdeEnvironment" class="pt.webdetails.cdf.dd.PentahoCdeEnvironment" scope="singleton">
+    <property name="pluginResourceLocationManager" ref="pluginResourceLocationManager"/>
+    <property name="resourceLoader" ref="pentahoPluginResourceLoader"/>
+    <property name="fileHandler" ref="fileHandler"/>
+    <property name="authorizationPolicy" ref="authorizationPolicy"/>
+    <property name="repositoryAccessFactory" ref="remoteRepositoryFactory"/>
+  </bean>
+
+  <bean id="pluginResourceLocationManager" class="pt.webdetails.cdf.dd.plugin.resource.PluginResourceLocationManager"/>
+  <bean id="pentahoPluginResourceLoader" class="pt.webdetails.cpf.resources.PentahoPluginResourceLoader" scope="prototype"/>
+  <bean id="fileHandler" class="pt.webdetails.cdf.dd.extapi.FileHandler" scope="prototype"/>
+  <!-- this <pen:bean /> declaration is not mandatory -->
+  <pen:bean id="authorizationPolicy" class="org.pentaho.platform.api.engine.IAuthorizationPolicy"/>
+
+  <bean id="renderApi" class="pt.webdetails.cdf.dd.api.RenderApi">
+    <property name="dashboardManager" ref="dashboardManager"/>
+  </bean>
+
+  <bean id="cache" class="pt.webdetails.cdf.dd.cache.impl.Cache" scope="singleton">
+    <constructor-arg ref="pentahoCdeEnvironment"/>
+  </bean>
+  <bean id="dashboardManager" class="pt.webdetails.cdf.dd.DashboardManager" scope="singleton" factory-method="getInstance" init-method="init">
+    <property name="cache" ref="cache"/>
+  </bean>
+
+</beans>

--- a/assemblies/platform/pom.xml
+++ b/assemblies/platform/pom.xml
@@ -14,5 +14,6 @@
     <module>pentaho-cdf-dd</module>
     <module>pentaho-cdf-dd-disabled</module>
     <module>pentaho-cdf-dd-samples</module>
+    <module>pentaho-cdf-dd-rca</module>
   </modules>
 </project>


### PR DESCRIPTION
New assembly uses cpf-pentaho-rca for remote (REST based) repository access.