### PR TITLE
[BACKLOG-25914] - Webdetails logo is still used in CDE editor

### DIFF
--- a/assemblies/platform/pentaho-cdf-dd/src/main/resources/resources/cdf-dd-default.html
+++ b/assemblies/platform/pentaho-cdf-dd/src/main/resources/resources/cdf-dd-default.html
@@ -83,8 +83,6 @@
         <div class="span-3 button cdfdd-about last" onclick="cdfdd.footerMode('about.fancybox')"> About </div>
         <div class="span-3 button cdfdd-documentation last" onclick="cdfdd.footerMode('documentation.fancybox')"> Documentation  </div>
 
-        <a class="webdetailsLogo" target="_blank" href="http://www.webdetails.pt" border="0"> <img src="./images/NAV/logo_webdetails.png"></a>
-
       </div>
     </div>
   </div>

--- a/assemblies/platform/pentaho-cdf-dd/src/main/resources/resources/cdf-dd.html
+++ b/assemblies/platform/pentaho-cdf-dd/src/main/resources/resources/cdf-dd.html
@@ -83,8 +83,6 @@
         <div class="span-3 button cdfdd-about last" onclick="cdfdd.footerMode('about.fancybox')"> About </div>
         <div class="span-3 button cdfdd-documentation last" onclick="cdfdd.footerMode('documentation.fancybox')"> Documentation  </div>
 
-        <a class="webdetailsLogo" target="_blank" href="http://www.webdetails.pt" border="0"> <img src="../resources/get?resource=/images/NAV/logo_webdetails.png"></a>
-
       </div>
     </div>
   </div>


### PR DESCRIPTION
Removed Webdetails' logo from the CDE Editor.