### PR TITLE
[BACKLOG-27567] Remove unneeded org.osgi dependency

### DIFF
--- a/assemblies/cde-renderer/feature/src/main/feature/feature.xml
+++ b/assemblies/cde-renderer/feature/src/main/feature/feature.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
-  <repository>mvn:org.apache.cxf.karaf/apache-cxf/${karaf.version}/xml/features</repository>
+  <repository>mvn:org.apache.cxf.karaf/apache-cxf/${cxf.version}/xml/features</repository>
 
   <feature name="pentaho-cde-renderer" version="${project.version}">
 
-    <feature version="${karaf.version}">cxf-jaxrs</feature>
+    <feature>cxf-jaxrs</feature>
 
   </feature>
 

--- a/assemblies/cde-renderer/karaf/pom.xml
+++ b/assemblies/cde-renderer/karaf/pom.xml
@@ -53,7 +53,6 @@
       <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
-        <version>${karaf-maven-plugin.version}</version>
         <extensions>true</extensions>
 
         <configuration>

--- a/osgi/impl/pom.xml
+++ b/osgi/impl/pom.xml
@@ -59,10 +59,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>net.sf.ehcache</groupId>
       <artifactId>ehcache-core</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,10 @@
     <jersey-bundle.version>1.19.1</jersey-bundle.version>
     <jetty.version>8.1.19.v20160209</jetty.version>
     <backport-util-concurrent.version>3.1</backport-util-concurrent.version>
-    <karaf.version>3.0.8</karaf.version>
 
     <junit.version>4.12</junit.version>
     <mockito-all.version>1.9.5</mockito-all.version>
 
-    <karaf-maven-plugin.version>${karaf.version}</karaf-maven-plugin.version>
     <karaf-maven-plugin.aggregateFeatures>false</karaf-maven-plugin.aggregateFeatures>
     <maven-filtering.version>3.1.1</maven-filtering.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@
     <junit.version>4.12</junit.version>
     <mockito-all.version>1.9.5</mockito-all.version>
 
-    <karaf-maven-plugin.aggregateFeatures>false</karaf-maven-plugin.aggregateFeatures>
     <maven-filtering.version>3.1.1</maven-filtering.version>
 
     <foundry.version>1.3.0.93</foundry.version>
@@ -375,42 +374,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <profiles>
-    <profile>
-      <!-- This profile generates a feature file to deploy in karaf. -->
-      <id>feature-generation</id>
-      <activation>
-        <file>
-          <exists>${basedir}/src/main/feature</exists>
-        </file>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.karaf.tooling</groupId>
-            <artifactId>karaf-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.karaf.tooling</groupId>
-          <artifactId>karaf-maven-plugin</artifactId>
-          <version>${karaf-maven-plugin.version}</version>
-          <extensions>true</extensions>
-          <configuration>
-            <aggregateFeatures>${karaf-maven-plugin.aggregateFeatures}</aggregateFeatures>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
     <jersey-bundle.version>1.19.1</jersey-bundle.version>
     <jetty.version>8.1.19.v20160209</jetty.version>
     <backport-util-concurrent.version>3.1</backport-util-concurrent.version>
-    <osgi.version>4.3.1</osgi.version>
     <karaf.version>3.0.8</karaf.version>
 
     <junit.version>4.12</junit.version>
@@ -339,18 +338,6 @@
         <artifactId>pentaho-cdf-js</artifactId>
         <version>${pentaho-cdf-plugin.version}</version>
         <type>zip</type>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.core</artifactId>
-        <version>${osgi.version}</version>
-        <scope>provided</scope>
         <exclusions>
           <exclusion>
             <artifactId>*</artifactId>


### PR DESCRIPTION
[BACKLOG-27567] Remove unneeded org.osgi dependency
[BACKLOG-27565] Centralize CXF version
[BACKLOG-27577] Centralize karaf dependencies management
[BACKLOG-27578] Use parent pom centralized profile for feature generation

@graimundo