### PR TITLE
[PDI-17667] Use of vulnerable component jetty 8.1.15, CVE-2017-9735, …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
     <jersey-multipart.version>1.19.1</jersey-multipart.version>
     <jersey-common.version>2.5.1</jersey-common.version>
     <jersey-bundle.version>1.19.1</jersey-bundle.version>
-    <jetty.version>8.1.19.v20160209</jetty.version>
     <backport-util-concurrent.version>3.1</backport-util-concurrent.version>
 
     <guava.version>17.0</guava.version>
@@ -373,11 +372,6 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlets</artifactId>
-        <version>${jetty.version}</version>
       </dependency>
       <dependency>
         <groupId>com.hds.ensemble</groupId>


### PR DESCRIPTION
…CVE-2017-7657 CVE-2015-2080

[PPP-4183] Use of Vulnerable Component: Multiple Jetty Components [Listed in Description] (CVE-2017-7656 | CVE-2017-7657 | CVE-2017-7658 | CVE-2015-2080 | CVE-2017-9735 )



Removed an unused Jetty dependency!


Depends on pentaho/maven-parent-poms#121

@pentaho-lmartins @pentaho/tatooine
@graimundo @nantunes 