### PR TITLE
[CDE-955] NewMapComponent - Can't set zoomlevels higher than 15

### DIFF
--- a/components/impls/core/src/main/javascript/components/NewMapComponent/amd/engines/openlayers2/MapEngineOpenLayers.js
+++ b/components/impls/core/src/main/javascript/components/NewMapComponent/amd/engines/openlayers2/MapEngineOpenLayers.js
@@ -201,7 +201,7 @@ define([
 
       var mapOptions = {
         zoom: this.options.viewport.zoomLevel["default"],
-        numZoomLevels: 19, // OpenLayers defaults to 16, but in OpenStreetMap default is 19.
+        numZoomLevels: 20, // OpenLayers defaults to 16, but in OpenStreetMap default is 20.
         zoomDuration: 10, // approximately match Google's zoom animation
         displayProjection: projectionWGS84,
         restrictedExtent: restrictedExtent,


### PR DESCRIPTION

Max zoom level is 19. But there are 20 zoom levels, since 0 also counts.

@pentaho-lmartins @ssamora 