### PR TITLE
[PDI-17667] Use of vulnerable component jetty 8.1.15, CVE-2017-9735, …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
     <jersey-multipart.version>1.19.1</jersey-multipart.version>
     <jersey-common.version>2.5.1</jersey-common.version>
     <jersey-bundle.version>1.19.1</jersey-bundle.version>
-    <jetty.version>8.1.19.v20160209</jetty.version>
     <backport-util-concurrent.version>3.1</backport-util-concurrent.version>
 
     <guava.version>17.0</guava.version>
@@ -361,11 +360,6 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlets</artifactId>
-        <version>${jetty.version}</version>
       </dependency>
       <dependency>
         <groupId>com.hds.ensemble</groupId>


### PR DESCRIPTION
…CVE-2017-7657 CVE-2015-2080

[PPP-4183] Use of Vulnerable Component: Multiple Jetty Components [Listed in Description] (CVE-2017-7656 | CVE-2017-7657 | CVE-2017-7658 | CVE-2015-2080 | CVE-2017-9735 )
[PDI-11851] Improve the jetty server version of Carte Server
[PPP-4402] Use of Vulnerable Component: jetty-server & jetty-util (CVE-2019-10246 | CVE-2019-10247)


To better cope with the synchronization with the Karaf upgrade, it was decided that the Jetty upgrade was to be split into two phases: the first would basically consist on centralizing the Jetty version on the parent POM (leaving the version as it is); the second phase (to be integrated into the Karaf upgrade development) would include the upgrade itself and any other changes required.

This PR belongs to phase 1 (check [maven-parent-poms#161](https://github.com/pentaho/maven-parent-poms/pull/161) for the complete list of PRs for phase 1).

**For this specific PR:**
Removed a Jetty dependency from the dependency manager!
Note that this change causes the Jetty version to regress to 8.1.15 (was 8.1.19), however, effectively, it changes nothing as, even before, the actual Jetty used at runtime was the one provided (which was 8.1.15).


