### PR TITLE
[BACKLOG-30893] Centralize commons-logging in parent pom

### DIFF
--- a/assemblies/pdi/pom.xml
+++ b/assemblies/pdi/pom.xml
@@ -28,7 +28,6 @@
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>${commons-logging.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,6 @@
     <commons-lang.version>2.6</commons-lang.version>
     <commons-jxpath.version>1.3</commons-jxpath.version>
     <commons-beanutils.version>1.9.3</commons-beanutils.version>
-    <commons-logging.version>1.1.1</commons-logging.version>
     <commons-collections.version>3.2.2</commons-collections.version>
 
     <jdom.version>1.0</jdom.version>
@@ -173,17 +172,6 @@
         <groupId>jdom</groupId>
         <artifactId>jdom</artifactId>
         <version>${jdom.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>${commons-logging.version}</version>
         <exclusions>
           <exclusion>
             <artifactId>*</artifactId>


### PR DESCRIPTION
Linked with this: pentaho/maven-parent-poms#163
