### PR TITLE
[SP-5327] Backport of CDE-1024 - Not define Default zoom level with Google as engine Map is not displayed (8.3 Suite)

### DIFF
--- a/components/impls/core/src/main/javascript/components/NewMapComponent/amd/engines/google/MapEngineGoogle.js
+++ b/components/impls/core/src/main/javascript/components/NewMapComponent/amd/engines/google/MapEngineGoogle.js
@@ -681,7 +681,8 @@ define([
 
     updateViewport: function(centerLongitude, centerLatitude, zoomLevel) {
       if (!zoomLevel) {
-        zoomLevel = this.options.viewport.zoomLevel["default"];
+        var ultimateZoomLevelDefault = 5;
+        zoomLevel = this.options.viewport.zoomLevel["default"] || ultimateZoomLevelDefault;
       }
       this.map.setZoom(zoomLevel);
       if (!this.zoomExtends()) {

--- a/components/impls/core/src/main/javascript/components/NewMapComponent/amd/engines/openlayers2/MapEngineOpenLayers.js
+++ b/components/impls/core/src/main/javascript/components/NewMapComponent/amd/engines/openlayers2/MapEngineOpenLayers.js
@@ -199,8 +199,9 @@ define([
         extent.northWest.longitude, extent.northWest.latitude
       ).transform(projectionWGS84, projectionMap);
 
+      var ultimateZoomLevelDefault = 5;
       var mapOptions = {
-        zoom: this.options.viewport.zoomLevel["default"],
+        zoom: this.options.viewport.zoomLevel["default"] || ultimateZoomLevelDefault,
         numZoomLevels: 20, // OpenLayers defaults to 16, but in OpenStreetMap default is 20.
         zoomDuration: 10, // approximately match Google's zoom animation
         displayProjection: projectionWGS84,
@@ -348,7 +349,8 @@ define([
         if (bounds) {
           this.map.zoomToExtent(bounds);
         } else {
-          this.map.zoomTo(this.options.viewport.zoomLevel["default"]);
+          var ultimateZoomLevelDefault = 5;
+          this.map.zoomTo(this.options.viewport.zoomLevel["default"] || ultimateZoomLevelDefault);
         }
       }
 


### PR DESCRIPTION
Merge Masters: @pentaho-lmartins and @smmribeiro
Cherry-picks:
* https://github.com/Webdetails/cde/commit/d11f2ca266c396616cc128bfde2d03ccfbca30e7
