### PR TITLE
[BACKLOG-35396] Fix integration tests for cde project to run in both …

### DIFF
--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/editor/DashboardEditorTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/editor/DashboardEditorTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,21 +13,12 @@
 
 package pt.webdetails.cdf.dd.editor;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
-import org.junit.After;
-import org.junit.Before;
+
 import org.junit.Test;
 
-public class DashboardEditorTest extends TestCase {
+import static org.junit.Assert.assertEquals;
 
-  @Before
-  public void setUp() throws Exception {
-  }
-
-  @After
-  public void tearDown() throws Exception {
-  }
+public class DashboardEditorTest {
 
   @Test
   public void testProcessDashboardSupportTag() {
@@ -35,14 +26,12 @@ public class DashboardEditorTest extends TestCase {
     final String editorPage = "<script type=\"text/javascript\" "
       + "src=\"@CDE_RENDERER_API@/getComponentDefinitions?supports=@SUPPORT_TYPE@\"></script>";
 
-    Assert.assertEquals(
+    assertEquals(
       "<script type=\"text/javascript\" src=\"@CDE_RENDERER_API@/getComponentDefinitions?supports=legacy\"></script>",
       DashboardEditor.processDashboardSupportTag( editorPage, false ) );
 
-    Assert.assertEquals(
+    assertEquals(
       "<script type=\"text/javascript\" src=\"@CDE_RENDERER_API@/getComponentDefinitions?supports=amd\"></script>",
       DashboardEditor.processDashboardSupportTag( editorPage, true ) );
-
   }
-
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsExpressionParameterComponentWriterTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsExpressionParameterComponentWriterTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,15 +13,14 @@
 
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.components.amd;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static pt.webdetails.cdf.dd.CdeConstants.Writer.PROPER_EXPRESSION_CONTEXT;
 
-public class CdfRunJsExpressionParameterComponentWriterTest extends TestCase {
+public class CdfRunJsExpressionParameterComponentWriterTest {
 
   private CdfRunJsExpressionParameterComponentWriter expressionParameterComponentWriter;
   protected static final String NEWLINE = System.getProperty( "line.separator" );
@@ -40,7 +39,7 @@ public class CdfRunJsExpressionParameterComponentWriterTest extends TestCase {
   public void testBindProperContext() {
     String functionToBind = "function() {}";
     String returnValue = "_.bind(" + functionToBind + ", " + PROPER_EXPRESSION_CONTEXT + ")";
-    Assert.assertEquals(
+    assertEquals(
         "Function is correctly bound to a proper context",
         returnValue,
         bind( functionToBind )
@@ -52,7 +51,7 @@ public class CdfRunJsExpressionParameterComponentWriterTest extends TestCase {
     String customParamValue = "value;       ";
     String returnValue = expressionParameterComponentWriter.sanitizeExpression( customParamValue );
     String expectedReturnValue = bind( "function() { return value" + NEWLINE + "}" ) + "()";
-    Assert.assertEquals( returnValue, expectedReturnValue );
+    assertEquals( returnValue, expectedReturnValue );
   }
 
   @Test
@@ -60,7 +59,7 @@ public class CdfRunJsExpressionParameterComponentWriterTest extends TestCase {
     String customParamValue = "value;" + NEWLINE + "//comment";
     String returnValue = expressionParameterComponentWriter.sanitizeExpression( customParamValue );
     String expectedReturnValue = bind( "function() { return value;" + NEWLINE + "//comment" + NEWLINE + "}" ) + "()";
-    Assert.assertEquals( returnValue, expectedReturnValue );
+    assertEquals( returnValue, expectedReturnValue );
   }
 
   @Test
@@ -68,7 +67,7 @@ public class CdfRunJsExpressionParameterComponentWriterTest extends TestCase {
     String customParamValue = "function() { return 'value'; }";
     String returnValue = expressionParameterComponentWriter.sanitizeExpression( customParamValue );
     String expectedReturnValue = bind( "function() { return 'value'; }" );
-    Assert.assertEquals( returnValue, expectedReturnValue );
+    assertEquals( returnValue, expectedReturnValue );
   }
 
   @Test
@@ -76,7 +75,7 @@ public class CdfRunJsExpressionParameterComponentWriterTest extends TestCase {
     String customParamValue = "function() {" + NEWLINE + "return 'value';" + NEWLINE + "}";
     String returnValue = expressionParameterComponentWriter.sanitizeExpression( customParamValue );
     String expectedReturnValue = bind( "function() {" + NEWLINE + "return 'value';" + NEWLINE + "}" );
-    Assert.assertEquals( returnValue, expectedReturnValue );
+    assertEquals( returnValue, expectedReturnValue );
   }
 
   private String bind( String toBind ) {

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsGenericComponentWriterTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsGenericComponentWriterTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,8 +13,6 @@
 
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.components.amd;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,13 +21,14 @@ import pt.webdetails.cdf.dd.model.core.writer.ThingWriteException;
 import pt.webdetails.cdf.dd.model.inst.GenericComponent;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteContext;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteOptions;
-import pt.webdetails.cdf.dd.model.meta.*;
+import pt.webdetails.cdf.dd.model.meta.GenericComponentType;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 import static pt.webdetails.cdf.dd.CdeConstants.Writer.INDENT1;
 import static pt.webdetails.cdf.dd.CdeConstants.Writer.NEWLINE;
 
-public class CdfRunJsGenericComponentWriterTest extends TestCase {
+public class CdfRunJsGenericComponentWriterTest {
 
   private static CdfRunJsGenericComponentWriter genericComponentWriter;
   private static CdfRunJsDashboardWriteContext context;
@@ -80,8 +79,6 @@ public class CdfRunJsGenericComponentWriterTest extends TestCase {
         .append( INDENT1 ).append( "name: \"test\"" ).append( NEWLINE )
         .append( "});" ).append( NEWLINE );
 
-    Assert.assertEquals( expectedReturnValue.toString(), out.toString() );
-
+    assertEquals( expectedReturnValue.toString(), out.toString() );
   }
-
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsParameterComponentWriterTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/amd/CdfRunJsParameterComponentWriterTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,8 +13,6 @@
 
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.components.amd;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,9 +22,10 @@ import pt.webdetails.cdf.dd.model.inst.ParameterComponent;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteContext;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteOptions;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
-public class CdfRunJsParameterComponentWriterTest extends TestCase {
+public class CdfRunJsParameterComponentWriterTest {
 
   private static final String NEWLINE = System.getProperty( "line.separator" );
   private static final String INDENT = "\t";
@@ -80,8 +79,6 @@ public class CdfRunJsParameterComponentWriterTest extends TestCase {
         .append( "dashboard.setBookmarkable(\"param1\");" ).append( NEWLINE )
         .append( "dashboard.setParameterViewMode(\"param1\", \"unused\");" ).append( NEWLINE );
 
-    Assert.assertEquals( out.toString(), dashboardResult.toString() );
-
+    assertEquals( out.toString(), dashboardResult.toString() );
   }
-
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/legacy/CdfRunJsExpressionParameterComponentWriterTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/legacy/CdfRunJsExpressionParameterComponentWriterTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,57 +13,43 @@
 
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.components.legacy;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
-public class CdfRunJsExpressionParameterComponentWriterTest extends TestCase {
+import static org.junit.Assert.assertEquals;
 
-  private CdfRunJsExpressionParameterComponentWriter expressionParameterComponentWriter;
+public class CdfRunJsExpressionParameterComponentWriterTest {
+
   protected static final String NEWLINE = System.getProperty( "line.separator" );
-
-  @Before
-  public void setUp() throws Exception {
-    expressionParameterComponentWriter = new CdfRunJsExpressionParameterComponentWriter();
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    expressionParameterComponentWriter = null;
-  }
 
   @Test
   public void testExpressionParameterComponentWriterSimpleValue() {
     String customParamValue = "value;       ";
-    String returnValue = expressionParameterComponentWriter.sanitizeExpression( customParamValue );
+    String returnValue = CdfRunJsExpressionParameterComponentWriter.sanitizeExpression( customParamValue );
     String expectedReturnValue = "function() { return value" + NEWLINE + "}()";
-    Assert.assertEquals( returnValue, expectedReturnValue );
+    assertEquals( expectedReturnValue, returnValue );
   }
 
   @Test
   public void testExpressionParameterComponentWriterMultipleLineValue() {
     String customParamValue = "value;" + NEWLINE + "//comment";
-    String returnValue = expressionParameterComponentWriter.sanitizeExpression( customParamValue );
+    String returnValue = CdfRunJsExpressionParameterComponentWriter.sanitizeExpression( customParamValue );
     String expectedReturnValue = "function() { return value;" + NEWLINE + "//comment" + NEWLINE + "}()";
-    Assert.assertEquals( returnValue, expectedReturnValue );
+    assertEquals( expectedReturnValue, returnValue );
   }
 
   @Test
   public void testExpressionParameterComponentWriterFunction() {
     String customParamValue = "function() { return 'value'; }";
-    String returnValue = expressionParameterComponentWriter.sanitizeExpression( customParamValue );
+    String returnValue = CdfRunJsExpressionParameterComponentWriter.sanitizeExpression( customParamValue );
     String expectedReturnValue = "function() { return 'value'; }";
-    Assert.assertEquals( returnValue, expectedReturnValue );
+    assertEquals( expectedReturnValue, returnValue );
   }
 
   @Test
   public void testExpressionParameterComponentWriterMultipleLineFunction() {
     String customParamValue = "function() {" + NEWLINE + "return 'value';" + NEWLINE + "}";
-    String returnValue = expressionParameterComponentWriter.sanitizeExpression( customParamValue );
+    String returnValue = CdfRunJsExpressionParameterComponentWriter.sanitizeExpression( customParamValue );
     String expectedReturnValue = "function() {" + NEWLINE + "return 'value';" + NEWLINE + "}";
-    Assert.assertEquals( returnValue, expectedReturnValue );
+    assertEquals( expectedReturnValue, returnValue );
   }
-
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/legacy/CdfRunJsParameterComponentWriterTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/components/legacy/CdfRunJsParameterComponentWriterTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,7 +13,6 @@
 
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.components.legacy;
 
-import junit.framework.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -22,6 +21,7 @@ import pt.webdetails.cdf.dd.model.core.writer.ThingWriteException;
 import pt.webdetails.cdf.dd.model.inst.ParameterComponent;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.legacy.PentahoCdfRunJsDashboardWriteContext;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 public class CdfRunJsParameterComponentWriterTest {
@@ -37,7 +37,6 @@ public class CdfRunJsParameterComponentWriterTest {
   public static void setUp() throws Exception {
     writer = new CdfRunJsParameterComponentWriter();
     context = Mockito.mock( PentahoCdfRunJsDashboardWriteContext.class );
-
   }
 
   @Test
@@ -45,7 +44,6 @@ public class CdfRunJsParameterComponentWriterTest {
     ParameterComponent parameterComponent = Mockito.mock( ParameterComponent.class );
     when( parameterComponent.tryGetPropertyValue( "propertyValue", "" ) ).thenReturn( "1" );
     when( parameterComponent.tryGetPropertyValue( "parameterViewRole", "unused" ) ).thenReturn( "unused" );
-
     when( context.getId( parameterComponent ) ).thenReturn( "param1" );
 
     StringBuilder dashboardResult = new StringBuilder();
@@ -53,10 +51,9 @@ public class CdfRunJsParameterComponentWriterTest {
     try {
       writer.write( dashboardResult, context, parameterComponent );
 
-      Assert.assertEquals( "Dashboards.addParameter(\"param1\", \"1\");" + NEWLINE
+      assertEquals( "Dashboards.addParameter(\"param1\", \"1\");" + NEWLINE
           + "Dashboards.setParameterViewMode(\"param1\", \"unused\");" + NEWLINE, dashboardResult.toString() );
     } catch ( ThingWriteException e ) {
     }
   }
-
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/CdfRunJsDashboardWriteContextForTesting.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/CdfRunJsDashboardWriteContextForTesting.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -24,7 +24,6 @@ import pt.webdetails.cdf.dd.structure.DashboardWcdfDescriptor;
 import pt.webdetails.cdf.dd.util.Utils;
 import pt.webdetails.cpf.repository.util.RepositoryHelper;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 
@@ -58,7 +57,7 @@ public class CdfRunJsDashboardWriteContextForTesting extends CdfRunJsDashboardWr
   public static Dashboard getDashboard( String path, boolean isSystem ) {
     Document wcdfDoc = null;
     try {
-      wcdfDoc = Utils.getDocument( new FileInputStream( new File( path ) ) );
+      wcdfDoc = Utils.getDocument( new FileInputStream( path ) );
     } catch ( DocumentException | FileNotFoundException e ) {
       e.printStackTrace();
     }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/CdfRunJsDashboardWriteContextTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/CdfRunJsDashboardWriteContextTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,20 +13,21 @@
 
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard;
 
-import junit.framework.Assert;
+import org.apache.commons.lang.StringUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import pt.webdetails.cdf.dd.CdeEngineForTests;
 import pt.webdetails.cdf.dd.ICdeEnvironment;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.amd.CdfRunJsThingWriterFactory;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class CdfRunJsDashboardWriteContextTest {
   private static CdfRunJsThingWriterFactory factory;
 
-  private static final String indent = "";
+  private static final String indent = StringUtils.EMPTY;
   private static final boolean bypassCacheRead = true;
 
   @BeforeClass
@@ -52,9 +53,7 @@ public class CdfRunJsDashboardWriteContextTest {
         bypassCacheRead,
         options );
 
-    Assert.assertEquals(
-        "http://localhost:8080/pentaho/plugin/pentaho-cdf-dd",
-        context.getRoot() );
+    assertEquals( "http://localhost:8080/pentaho/plugin/pentaho-cdf-dd", context.getRoot() );
 
     // test fallback to relative path if options.absRoot is invalid
     options = new CdfRunJsDashboardWriteOptions(
@@ -68,9 +67,7 @@ public class CdfRunJsDashboardWriteContextTest {
       bypassCacheRead,
       options );
 
-    Assert.assertEquals(
-      "/pentaho/plugin/pentaho-cdf-dd",
-      context.getRoot() );
+    assertEquals( "/pentaho/plugin/pentaho-cdf-dd", context.getRoot() );
 
     // setup context for testing a relative path
     options = new CdfRunJsDashboardWriteOptions(
@@ -84,8 +81,6 @@ public class CdfRunJsDashboardWriteContextTest {
       bypassCacheRead,
       options );
 
-    Assert.assertEquals(
-      "/pentaho/plugin/pentaho-cdf-dd",
-      context.getRoot() );
+    assertEquals( "/pentaho/plugin/pentaho-cdf-dd", context.getRoot() );
   }
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/CdfRunJsDashboardWriteOptionsTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/CdfRunJsDashboardWriteOptionsTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -14,12 +14,13 @@
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard;
 
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.junit.Test;
 import pt.webdetails.cdf.dd.CdeConstants;
 
-public class CdfRunJsDashboardWriteOptionsTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CdfRunJsDashboardWriteOptionsTest {
 
   @Test
   public void testAlias() {
@@ -32,25 +33,24 @@ public class CdfRunJsDashboardWriteOptionsTest extends TestCase {
     String spacedAlias3 = spacedAlias1 + CdeConstants.DASHBOARD_ALIAS_TAG + prefix;
     String messyAlias = "I-[~!@#$%^&*(){}|.,]-=_+|;'\"?<>~`";
 
-    Assert.assertEquals( "Alias is empty", emptyAlias, createAndGetAlias( emptyAlias ) );
-    Assert.assertEquals( "Alias correctly set", normalAlias1, createAndGetAlias( normalAlias1 ) );
-    Assert.assertEquals( "Alias correctly set", normalAlias2, createAndGetAlias( normalAlias2 ) );
-    Assert.assertEquals( "Alias correctly set", "id_" + spacedAlias1.replace( " ", "32" ),
+    assertEquals( "Alias is empty", emptyAlias, createAndGetAlias( emptyAlias ) );
+    assertEquals( "Alias correctly set", normalAlias1, createAndGetAlias( normalAlias1 ) );
+    assertEquals( "Alias correctly set", normalAlias2, createAndGetAlias( normalAlias2 ) );
+    assertEquals( "Alias correctly set", "id_" + spacedAlias1.replace( " ", "32" ),
       createAndGetAlias( spacedAlias1 ) );
 
-    Assert.assertTrue( createAndGetAlias( spacedAlias2 ).startsWith( "id_" + spacedAlias1.replace( " ", "32" ) ) );
-    Assert.assertTrue( createAndGetAlias( spacedAlias2 ).endsWith( CdeConstants.DASHBOARD_ALIAS_TAG ) );
+    assertTrue( createAndGetAlias( spacedAlias2 ).startsWith( "id_" + spacedAlias1.replace( " ", "32" ) ) );
+    assertTrue( createAndGetAlias( spacedAlias2 ).endsWith( CdeConstants.DASHBOARD_ALIAS_TAG ) );
 
-    Assert.assertTrue( createAndGetAlias( spacedAlias3 ).startsWith( "id_" + spacedAlias1.replace( " ", "32" ) ) );
-    Assert.assertTrue( createAndGetAlias( spacedAlias3 ).endsWith( prefix.replace( " ", "32" ) ) );
-    Assert.assertTrue( createAndGetAlias( spacedAlias3 ).contains( CdeConstants.DASHBOARD_ALIAS_TAG ) );
+    assertTrue( createAndGetAlias( spacedAlias3 ).startsWith( "id_" + spacedAlias1.replace( " ", "32" ) ) );
+    assertTrue( createAndGetAlias( spacedAlias3 ).endsWith( prefix.replace( " ", "32" ) ) );
+    assertTrue( createAndGetAlias( spacedAlias3 ).contains( CdeConstants.DASHBOARD_ALIAS_TAG ) );
 
-    Assert.assertEquals( "id_I-9112633643536379438424041123125124464493-61_4312459393463606212696",
+    assertEquals( "id_I-9112633643536379438424041123125124464493-61_4312459393463606212696",
       createAndGetAlias( messyAlias ) );
   }
 
   private String createAndGetAlias( String alias ) {
     return new CdfRunJsDashboardWriteOptions( alias, false, false, false, "", "" ).getAliasPrefix();
   }
-
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardModuleWriterTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardModuleWriterTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,8 +13,6 @@
 
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.amd;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -32,10 +30,23 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.mockito.Mockito.*;
-import static pt.webdetails.cdf.dd.CdeConstants.Writer.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.DASHBOARD_MODULE_GET_MESSAGES_PATH;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.DASHBOARD_MODULE_NORMALIZE_ALIAS;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.DASHBOARD_MODULE_PROCESS_COMPONENTS;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.DASHBOARD_MODULE_RENDERER;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.DASHBOARD_MODULE_SETUP_DOM;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.DASHBOARD_MODULE_START_EMPTY_ALIAS;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.DASHBOARD_MODULE_STOP;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.DEFINE_START;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.DEFINE_STOP;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.NEWLINE;
 
-public class CdfRunJsDashboardModuleWriterTest extends TestCase {
+public class CdfRunJsDashboardModuleWriterTest {
 
   private static final String MESSAGES_PATH = "/test/repos/:path:to:dash.wcdf/";
 
@@ -75,7 +86,7 @@ public class CdfRunJsDashboardModuleWriterTest extends TestCase {
     doReturn( "jsFileRsrcPath1" ).when( context ).replaceTokensAndAlias( "jsFileRsrcPath1" );
     doReturn( "cssFileRsrcPath1" ).when( context ).replaceTokensAndAlias( "cssFileRsrcPath1" );
 
-    Map<String, String> testComponentModules = new LinkedHashMap<String, String>();
+    Map<String, String> testComponentModules = new LinkedHashMap<>();
     testComponentModules.put( "TestComponent1", "cdf/components/TestComponent1" );
     testComponentModules.put( "TestComponent2", "cdf/components/TestComponent2" );
 
@@ -83,8 +94,8 @@ public class CdfRunJsDashboardModuleWriterTest extends TestCase {
     doReturn( testComponentModules ).when( dashboardWriterSpy )
       .writeFileResourcesRequireJSPathConfig( out, testResources, context );
 
-    ArrayList<String> moduleIds = new ArrayList<String>();
-    ArrayList<String> moduleClassNames = new ArrayList<String>();
+    ArrayList<String> moduleIds = new ArrayList<>();
+    ArrayList<String> moduleClassNames = new ArrayList<>();
 
     dashboardWriterSpy.addDefaultDashboardModules( moduleIds, moduleClassNames );
     moduleIds.add( "cdf/components/TestComponent1" );
@@ -107,7 +118,6 @@ public class CdfRunJsDashboardModuleWriterTest extends TestCase {
       .append( MessageFormat.format( DEFINE_START,
         StringUtils.join( moduleIds, "', '" ),
         StringUtils.join( moduleClassNames, ", " ) ) )
-      .append( "" )
       .append( MessageFormat.format( DASHBOARD_MODULE_START_EMPTY_ALIAS, layout ) )
       .append( MessageFormat.format( DASHBOARD_MODULE_NORMALIZE_ALIAS, "\" + this._alias + \"" ) )
       .append( MessageFormat.format( DASHBOARD_MODULE_GET_MESSAGES_PATH, MESSAGES_PATH ) )
@@ -118,7 +128,7 @@ public class CdfRunJsDashboardModuleWriterTest extends TestCase {
       .append( DASHBOARD_MODULE_STOP ).append( NEWLINE )
       .append( DEFINE_STOP );
 
-    Assert.assertEquals(
+    assertEquals(
       dashboardResult.toString(),
       dashboardWriterSpy
         .wrapRequireModuleDefinitions( layout, testResources, testComponentModules, content, context ) );
@@ -138,7 +148,7 @@ public class CdfRunJsDashboardModuleWriterTest extends TestCase {
 
     dashboardWriterSpy.writeRequireJsExecutionFunction( out, moduleIds, moduleClassNames );
 
-    Assert.assertEquals(
+    assertEquals(
       MessageFormat.format( DEFINE_START,
         "cdf/components/TestComponent1', 'cde/resources/jsFileRsrc1', 'css!cde/resources/cssFileRsrc1",
         "TestComponent1, jsFileRsrc1" ),
@@ -151,12 +161,12 @@ public class CdfRunJsDashboardModuleWriterTest extends TestCase {
       ":path.cdfde:to.wcdf:file", ":path.cdfde/to.wcdf:file" };
     for ( int i = 0; i < paths.length; i++ ) {
       // everything that ends in .cdfde will now end in .wcdf
-      Assert.assertEquals(
+      assertEquals(
         dashboardWriterSpy.replaceCdfdeExtension( paths[ i ] + ".cdfde" ), paths[ i ] + ".wcdf" );
     }
     for ( int i = 0; i < paths.length; i++ ) {
       // if it doesn't end in .cdfde, it will just be returned the same
-      Assert.assertEquals(
+      assertEquals(
         dashboardWriterSpy.replaceCdfdeExtension( paths[ i ] ), paths[ i ] );
     }
   }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriterTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/amd/CdfRunJsDashboardWriterTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,8 +13,6 @@
 
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.amd;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONException;
@@ -49,10 +47,33 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.mockito.Mockito.*;
-import static pt.webdetails.cdf.dd.CdeConstants.Writer.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.CDE_AMD_BASE_COMPONENT_PATH;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.CDE_AMD_REPO_COMPONENT_PATH;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.CDF_AMD_BASE_COMPONENT_PATH;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.DASHBOARD_DECLARATION;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.DASHBOARD_DECLARATION_DEBUG;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.DASHBOARD_INIT;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.GET_WCDF_SETTINGS_FUNCTION;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.INDENT1;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.PLUGIN_COMPONENT_FOLDER;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.REQUIRE_START;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.REQUIRE_STOP;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.SCRIPT;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.TITLE;
+import static pt.webdetails.cdf.dd.CdeConstants.Writer.WEBCONTEXT;
 
-public class CdfRunJsDashboardWriterTest extends TestCase {
+public class CdfRunJsDashboardWriterTest {
 
   private static Dashboard dash;
   private static DashboardWcdfDescriptor dashboardWcdfDescriptor;
@@ -91,7 +112,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
   public void testWriteLayout() throws Exception {
 
     doReturn( 0 ).when( dash ).getLayoutCount();
-    Assert.assertEquals( "", dashboardWriterSpy.writeLayout( context, dash ) );
+    assertEquals( "", dashboardWriterSpy.writeLayout( context, dash ) );
 
     doReturn( 1 ).when( dash ).getLayoutCount();
     LayoutComponent comp = Mockito.mock( LayoutComponent.class );
@@ -108,7 +129,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
 
     String layout = dashboardWriterSpy.writeLayout( context, dash );
 
-    Assert.assertEquals( sampleLayout.toString(), layout );
+    assertEquals( sampleLayout, layout );
 
     doReturn( "TestResourcePath1" ).when( context ).replaceTokensAndAlias( anyString() );
   }
@@ -122,7 +143,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     testResources.add( ResourceKind.CSS, ResourceType.FILE, "cssFileRsrc1", "cssFileRsrcPath1", "cssFileRsrc1" );
     testResources.add( ResourceKind.CSS, ResourceType.CODE, "cssCodeRsrc1", "cssCodeRsrcPath1", "cssCodeRsrc1" );
 
-    Assert.assertEquals( "cssCodeRsrc1" + NEWLINE, dashboardWriterSpy.writeCssCodeResources( testResources ) );
+    assertEquals( "cssCodeRsrc1" + NEWLINE, dashboardWriterSpy.writeCssCodeResources( testResources ) );
   }
 
   @Test
@@ -134,7 +155,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     testResources.add( ResourceKind.CSS, ResourceType.FILE, "cssFileRsrc1", "cssFileRsrcPath1", "cssFileRsrc1" );
     testResources.add( ResourceKind.CSS, ResourceType.CODE, "cssCodeRsrc1", "cssCodeRsrcPath1", "cssCodeRsrc1" );
 
-    Assert.assertEquals( "jsCodeRsrc1" + NEWLINE, dashboardWriterSpy.writeJsCodeResources( testResources ) );
+    assertEquals( "jsCodeRsrc1" + NEWLINE, dashboardWriterSpy.writeJsCodeResources( testResources ) );
   }
 
   @Test
@@ -154,7 +175,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     doReturn( dashboardWcdfDescriptor ).when( dash ).getWcdf();
 
     // Data Source Components
-    List<DataSourceComponent> dashComponentList = new ArrayList<DataSourceComponent>();
+    List<DataSourceComponent> dashComponentList = new ArrayList<>();
 
     DataSourceComponent dataSourceComp1 = mock( DataSourceComponent.class );
     doReturn( "dataSourceComp1" ).when( dataSourceComp1 ).getName();
@@ -163,7 +184,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     doReturn( dashComponentList ).when( dash ).getDataSources();
 
     // Regular Components
-    List<Component> componentList = new ArrayList<Component>();
+    List<Component> componentList = new ArrayList<>();
 
     Component comp1 = mock( Component.class );
     Component comp2 = mock( Component.class );
@@ -225,17 +246,17 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     StringBuilder out = new StringBuilder();
     Map<String, String> componentModules = dashboardWriterSpy.writeComponents( context, dash, out );
 
-    Assert.assertEquals(
+    assertEquals(
       INDENT1 + "dashboard.addDataSource(\"dataSourceComp1\", );" + NEWLINE + NEWLINE
         + NEWLINE + "dashboard.addComponents([comp1, comp2, comp3]);" + NEWLINE,
       out.toString() );
 
     // invalid components are not added
-    Assert.assertEquals( 3, componentModules.size() );
-    Assert.assertEquals( true, componentModules.containsKey( "Comp1Component" ) );
-    Assert.assertEquals( true, componentModules.containsKey( "Comp2Component" ) );
-    Assert.assertEquals( false, componentModules.containsKey( "InvalidComponent" ) );
-    Assert.assertEquals( true, componentModules.containsKey( "Comp3Component" ) );
+    assertEquals( 3, componentModules.size() );
+    assertTrue( componentModules.containsKey( "Comp1Component" ) );
+    assertTrue( componentModules.containsKey( "Comp2Component" ) );
+    assertFalse( componentModules.containsKey( "InvalidComponent" ) );
+    assertTrue( componentModules.containsKey( "Comp3Component" ) );
   }
 
   @Test
@@ -245,14 +266,14 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     Component comp = mock( Component.class );
     doReturn( true ).when( comp ).isPrimitiveComponent();
     doReturn( true ).when( comp ).isComponentStaticSystemOrigin();
-    Assert.assertEquals(
+    assertEquals(
       CDF_AMD_BASE_COMPONENT_PATH + className,
       dashboardWriterSpy.writeComponentModuleId( comp, className ) );
     // custom component from static system origin
     comp = mock( Component.class );
     doReturn( true ).when( comp ).isCustomComponent();
     doReturn( true ).when( comp ).isComponentStaticSystemOrigin();
-    Assert.assertEquals(
+    assertEquals(
       CDE_AMD_BASE_COMPONENT_PATH + className,
       dashboardWriterSpy.writeComponentModuleId( comp, className ) );
     // custom component from plugin repository origin with no implementation path
@@ -262,7 +283,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     doReturn( true ).when( comp ).isComponentPluginRepositoryOrigin();
     doReturn( null ).when( comp ).getComponentImplementationPath();
     doReturn( "comp/component.xml" ).when( comp ).getComponentSourcePath();
-    Assert.assertEquals(
+    assertEquals(
       CDE_AMD_REPO_COMPONENT_PATH + "comp/" + className,
       dashboardWriterSpy.writeComponentModuleId( comp, className ) );
     // custom component from plugin repository origin
@@ -271,7 +292,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     doReturn( false ).when( comp ).isComponentStaticSystemOrigin();
     doReturn( true ).when( comp ).isComponentPluginRepositoryOrigin();
     doReturn( "comp/comp.js" ).when( comp ).getComponentImplementationPath();
-    Assert.assertEquals(
+    assertEquals(
       CDE_AMD_REPO_COMPONENT_PATH + "comp/comp",
       dashboardWriterSpy.writeComponentModuleId( comp, className ) );
     // custom component from other plugin static system origin
@@ -282,13 +303,13 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     doReturn( true ).when( comp ).isComponentOtherPluginStaticSystemOrigin();
     doReturn( "sparkl" ).when( comp ).getPluginIdFromOrigin();
     doReturn( "comp/comp.js" ).when( comp ).getComponentImplementationPath();
-    Assert.assertEquals(
+    assertEquals(
       "sparkl" + PLUGIN_COMPONENT_FOLDER + "CompComponent",
       dashboardWriterSpy.writeComponentModuleId( comp, className ) );
     // widget components are not supported
     comp = mock( Component.class );
     doReturn( true ).when( comp ).isWidgetComponent();
-    Assert.assertEquals( "", dashboardWriterSpy.writeComponentModuleId( comp, className ) );
+    assertEquals( "", dashboardWriterSpy.writeComponentModuleId( comp, className ) );
   }
 
   @Test
@@ -296,7 +317,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     DashboardWcdfDescriptor wcdf = Mockito.mock( DashboardWcdfDescriptor.class );
     doReturn( "Title 1" ).when( wcdf ).getTitle();
     doReturn( wcdf ).when( dash ).getWcdf();
-    Assert.assertEquals(
+    assertEquals(
       MessageFormat.format( TITLE, dash.getWcdf().getTitle() ) + NEWLINE
         + MessageFormat.format( SCRIPT, dashboardWriterSpy.writeWebcontext( "cdf", true ) ),
       dashboardWriterSpy.writeHeaders( dash ) );
@@ -304,7 +325,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
 
   @Test
   public void testWriteWebContext() {
-    Assert.assertEquals(
+    assertEquals(
       MessageFormat.format( WEBCONTEXT, "cdf", "true" ),
       dashboardWriterSpy.writeWebcontext( "cdf", true ) );
   }
@@ -314,7 +335,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     // layout
     final String layout = "<div id='content'></div>";
     //component modules
-    Map<String, String> componentModules = new LinkedHashMap();
+    Map<String, String> componentModules = new LinkedHashMap<>();
     // components sourcecode
     final String components = "var comp = new CompComponent();";
     componentModules.put( "comp", "comp/CompComponent" );
@@ -325,7 +346,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     doReturn( "content" ).when( dashboardWriterSpy )
       .wrapRequireDefinitions( resources, componentModules, components, context );
 
-    Assert.assertEquals(
+    assertEquals(
       layout + NEWLINE
         + "<script language=\"javascript\" type=\"text/javascript\">" + NEWLINE
         + "content" + NEWLINE
@@ -364,7 +385,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
 
     doReturn( dashboardWcdfDescriptor ).when( dash ).getWcdf();
 
-    Assert.assertEquals(
+    assertEquals(
       MessageFormat.format( GET_WCDF_SETTINGS_FUNCTION, dashboardWcdfDescriptor.toJSON().toString( 6 ) ),
       dashboardWriterSpy.writeWcdfSettings( dash ) );
   }
@@ -381,7 +402,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     doReturn( "jsFileRsrcPath1" ).when( context ).replaceTokensAndAlias( "jsFileRsrcPath1" );
     doReturn( "cssFileRsrcPath1" ).when( context ).replaceTokensAndAlias( "cssFileRsrcPath1" );
 
-    Map<String, String> testComponentModules = new LinkedHashMap<String, String>();
+    Map<String, String> testComponentModules = new LinkedHashMap<>();
     testComponentModules.put( "TestComponent1", "cdf/components/TestComponent1" );
     testComponentModules.put( "TestComponent2", "cdf/components/TestComponent2" );
 
@@ -389,8 +410,8 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     doReturn( testComponentModules ).when( dashboardWriterSpy )
       .writeFileResourcesRequireJSPathConfig( out, testResources, context );
 
-    ArrayList<String> moduleIds = new ArrayList<String>();
-    ArrayList<String> moduleClassNames = new ArrayList<String>();
+    ArrayList<String> moduleIds = new ArrayList<>();
+    ArrayList<String> moduleClassNames = new ArrayList<>();
 
     // Add dashboard default AMD module ids and class names
     moduleIds.add( AmdModule.DASHBOARD_BLUEPRINT.getId() );
@@ -438,7 +459,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
       .append( DASHBOARD_INIT )
       .append( REQUIRE_STOP );
 
-    Assert.assertEquals(
+    assertEquals(
       dashboardResult.toString(),
       dashboardWriterSpy.wrapRequireDefinitions( testResources, testComponentModules, content, context ) );
 
@@ -457,7 +478,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
       .append( DASHBOARD_INIT )
       .append( REQUIRE_STOP );
 
-    Assert.assertEquals(
+    assertEquals(
       dashboardResult.toString(),
       dashboardWriterSpy.wrapRequireDefinitions( testResources, testComponentModules, content, context ) );
 
@@ -468,23 +489,20 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
   public void testDashboardType() {
     CdfRunJsDashboardWriter dashboardWriter =
       new CdfRunJsDashboardWriter( DashboardWcdfDescriptor.DashboardRendererType.BLUEPRINT );
-    assertEquals( dashboardWriter.getDashboardModule().getId(), "cdf/Dashboard.Blueprint" );
-    dashboardWriter =
-      new CdfRunJsDashboardWriter( DashboardWcdfDescriptor.DashboardRendererType.BOOTSTRAP );
-    assertEquals( dashboardWriter.getDashboardModule().getId(), "cdf/Dashboard.Bootstrap" );
-    dashboardWriter =
-      new CdfRunJsDashboardWriter( DashboardWcdfDescriptor.DashboardRendererType.MOBILE );
-    assertEquals( dashboardWriter.getDashboardModule().getId(), "cdf/Dashboard.Mobile" );
-    dashboardWriter =
-      new CdfRunJsDashboardWriter( DashboardWcdfDescriptor.DashboardRendererType.CLEAN );
-    assertEquals( dashboardWriter.getDashboardModule().getId(), "cdf/Dashboard.Clean" );
+    assertEquals( "cdf/Dashboard.Blueprint", dashboardWriter.getDashboardModule().getId() );
+    dashboardWriter = new CdfRunJsDashboardWriter( DashboardWcdfDescriptor.DashboardRendererType.BOOTSTRAP );
+    assertEquals( "cdf/Dashboard.Bootstrap", dashboardWriter.getDashboardModule().getId() );
+    dashboardWriter = new CdfRunJsDashboardWriter( DashboardWcdfDescriptor.DashboardRendererType.MOBILE );
+    assertEquals( "cdf/Dashboard.Mobile", dashboardWriter.getDashboardModule().getId() );
+    dashboardWriter = new CdfRunJsDashboardWriter( DashboardWcdfDescriptor.DashboardRendererType.CLEAN );
+    assertEquals( "cdf/Dashboard.Clean", dashboardWriter.getDashboardModule().getId() );
   }
 
   @Test
   public void testWriteRequireJsExecutionFunction() {
     StringBuilder out = new StringBuilder();
-    ArrayList<String> moduleIds = new ArrayList<String>();
-    ArrayList<String> moduleClassNames = new ArrayList<String>();
+    ArrayList<String> moduleIds = new ArrayList<>();
+    ArrayList<String> moduleClassNames = new ArrayList<>();
     moduleIds.add( "cdf/components/TestComponent1" );
     moduleIds.add( "cde/resources/jsFileRsrc1" );
     moduleIds.add( "css!cde/resources/cssFileRsrc1" );
@@ -494,7 +512,7 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
 
     dashboardWriterSpy.writeRequireJsExecutionFunction( out, moduleIds, moduleClassNames );
 
-    Assert.assertEquals(
+    assertEquals(
       MessageFormat.format(
         REQUIRE_START,
         "cdf/components/TestComponent1',"
@@ -508,13 +526,13 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
   @Test
   public void testGetDashboardModule() {
     doReturn( DashboardWcdfDescriptor.DashboardRendererType.BLUEPRINT ).when( dashboardWriterSpy ).getType();
-    Assert.assertEquals( AmdModule.DASHBOARD_BLUEPRINT, dashboardWriterSpy.getDashboardModule() );
+    assertEquals( AmdModule.DASHBOARD_BLUEPRINT, dashboardWriterSpy.getDashboardModule() );
     doReturn( DashboardWcdfDescriptor.DashboardRendererType.BOOTSTRAP ).when( dashboardWriterSpy ).getType();
-    Assert.assertEquals( AmdModule.DASHBOARD_BOOTSTRAP, dashboardWriterSpy.getDashboardModule() );
+    assertEquals( AmdModule.DASHBOARD_BOOTSTRAP, dashboardWriterSpy.getDashboardModule() );
     doReturn( DashboardWcdfDescriptor.DashboardRendererType.MOBILE ).when( dashboardWriterSpy ).getType();
-    Assert.assertEquals( AmdModule.DASHBOARD_MOBILE, dashboardWriterSpy.getDashboardModule() );
+    assertEquals( AmdModule.DASHBOARD_MOBILE, dashboardWriterSpy.getDashboardModule() );
     doReturn( DashboardWcdfDescriptor.DashboardRendererType.CLEAN ).when( dashboardWriterSpy ).getType();
-    Assert.assertEquals( AmdModule.DASHBOARD_CLEAN, dashboardWriterSpy.getDashboardModule() );
+    assertEquals( AmdModule.DASHBOARD_CLEAN, dashboardWriterSpy.getDashboardModule() );
   }
 
   @Test
@@ -611,7 +629,6 @@ public class CdfRunJsDashboardWriterTest extends TestCase {
     ArrayList<String> expectedClassNames = new ArrayList<String>();
     expectedClassNames.add( "jsFileRsrc1" );
 
-    Assert.assertEquals( expectedClassNames,
-      dashboardWriterSpy.getJsModuleClassNames( testResources ) );
+    assertEquals( expectedClassNames, dashboardWriterSpy.getJsModuleClassNames( testResources ) );
   }
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/legacy/PentahoCdfRunJsDashboardWriteContextTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/dashboard/legacy/PentahoCdfRunJsDashboardWriteContextTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,14 +13,15 @@
 
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.legacy;
 
-import junit.framework.Assert;
-import org.junit.Test;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import pt.webdetails.cdf.dd.model.inst.Dashboard;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteContextForTesting;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteOptions;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.legacy.CdfRunJsThingWriterFactory;
 import pt.webdetails.cpf.repository.util.RepositoryHelper;
+
+import static org.junit.Assert.assertEquals;
 
 public class PentahoCdfRunJsDashboardWriteContextTest {
 
@@ -62,16 +63,13 @@ public class PentahoCdfRunJsDashboardWriteContextTest {
     String jsResourceExpected = CDE_PLUGIN_URL
       + RepositoryHelper.joinPaths( GET_RESOURCES, ROOT, TEST_FOLDER, "script.js" ).substring( 1 );
     String cssResourceExpected =
-      CDE_PLUGIN_URL + RepositoryHelper.joinPaths( GET_RESOURCES, ROOT, TEST_FOLDER, "style.css" ).substring(
-        1 );
+      CDE_PLUGIN_URL + RepositoryHelper.joinPaths( GET_RESOURCES, ROOT, TEST_FOLDER, "style.css" ).substring( 1 );
     String absoluteExpected =
       CDE_PLUGIN_URL + RepositoryHelper.joinPaths( GET_RESOURCES, ROOT, "style.css" ).substring( 1 );
     String solutionAbsoluteResourceExpected = CDE_PLUGIN_URL
-      + RepositoryHelper.joinPaths( GET_RESOURCES, ROOT, TEST_FOLDER, "script.js" ).substring(
-        1 );
+      + RepositoryHelper.joinPaths( GET_RESOURCES, ROOT, TEST_FOLDER, "script.js" ).substring( 1 );
     String solutionRelativeResourceExpected =
-      CDE_PLUGIN_URL + RepositoryHelper.joinPaths( GET_RESOURCES, ROOT, "script.js" ).substring(
-        1 );
+      CDE_PLUGIN_URL + RepositoryHelper.joinPaths( GET_RESOURCES, ROOT, "script.js" ).substring( 1 );
 
     String jsResourceReplaced = removeParams( context.replaceTokens( jsResource ) );
     String cssResourceReplaced = removeParams( context.replaceTokens( cssResource ) );
@@ -79,13 +77,13 @@ public class PentahoCdfRunJsDashboardWriteContextTest {
     String solutionAbsoluteResourceReplaced = removeParams( context.replaceTokens( solutionAbsoluteResource ) );
     String solutionRelativeResourceReplaced = removeParams( context.replaceTokens( solutionRelativeResource ) );
 
-    Assert.assertEquals( "${res:script.js} replacement failed", jsResourceExpected, jsResourceReplaced );
-    Assert.assertEquals( "${res:style.css} replacement failed", cssResourceExpected, cssResourceReplaced );
-    Assert.assertEquals( "${res:/src/test/resources/style.css} replacement failed", absoluteExpected,
+    assertEquals( "${res:script.js} replacement failed", jsResourceExpected, jsResourceReplaced );
+    assertEquals( "${res:style.css} replacement failed", cssResourceExpected, cssResourceReplaced );
+    assertEquals( "${res:/src/test/resources/style.css} replacement failed", absoluteExpected,
       absoluteResourceReplaced );
-    Assert.assertEquals( "${solution:script.js} replacement failed", solutionAbsoluteResourceExpected,
+    assertEquals( "${solution:script.js} replacement failed", solutionAbsoluteResourceExpected,
       solutionAbsoluteResourceReplaced );
-    Assert.assertEquals( "${solution:/src/test/resources/script.js} replacement failed", solutionRelativeResourceExpected,
+    assertEquals( "${solution:/src/test/resources/script.js} replacement failed", solutionRelativeResourceExpected,
       solutionRelativeResourceReplaced );
   }
 
@@ -99,37 +97,33 @@ public class PentahoCdfRunJsDashboardWriteContextTest {
 
     // Absolute paths
     String filePath = "/pentaho-cdf-dd/css/master.css";
-    String systemResourceExpected =
-      "/pentaho/plugin/pentaho-cdf-dd/api/resources/system/mockPlugin" + filePath;
+    String systemResourceExpected = "/pentaho/plugin/pentaho-cdf-dd/api/resources/system/mockPlugin" + filePath;
 
-    Assert.assertEquals(
+    assertEquals(
       "absolute ${system:} replacement failed",
       systemResourceExpected,
       context.replaceTokens( "${system:" + filePath + "}" ) );
 
     // Relative paths
     filePath = "pentaho-cdf-dd/css/master.css";
-    systemResourceExpected =
-      "/pentaho/plugin/pentaho-cdf-dd/api/resources/system/mockPlugin/" + filePath;
-    Assert.assertEquals(
+    systemResourceExpected = "/pentaho/plugin/pentaho-cdf-dd/api/resources/system/mockPlugin/" + filePath;
+    assertEquals(
       "relative ${system:} replacement failed",
       systemResourceExpected,
       context.replaceTokens( "${system:" + filePath + "}" )
     );
 
     filePath = "./pentaho-cdf-dd/css/master.css";
-    systemResourceExpected =
-      "/pentaho/plugin/pentaho-cdf-dd/api/resources/system/mockPlugin/" + filePath;
-    Assert.assertEquals(
+    systemResourceExpected = "/pentaho/plugin/pentaho-cdf-dd/api/resources/system/mockPlugin/" + filePath;
+    assertEquals(
       "relative ${system:} replacement failed",
       systemResourceExpected,
       context.replaceTokens( "${system:" + filePath + "}" )
     );
 
     filePath = "../pentaho-cdf-dd/css/master.css";
-    systemResourceExpected =
-      "/pentaho/plugin/pentaho-cdf-dd/api/resources/system/mockPlugin/" + filePath;
-    Assert.assertEquals(
+    systemResourceExpected = "/pentaho/plugin/pentaho-cdf-dd/api/resources/system/mockPlugin/" + filePath;
+    assertEquals(
       "relative ${system:} replacement failed",
       systemResourceExpected,
       context.replaceTokens( "${system:" + filePath + "}" )
@@ -153,21 +147,19 @@ public class PentahoCdfRunJsDashboardWriteContextTest {
       + RepositoryHelper.joinPaths( GET_RESOURCES, ROOT, TEST_FOLDER, "script.js" );
 
     jsResourceReplaced = removeParams( context.replaceTokens( jsResource ) );
-    Assert.assertEquals( "${res:script.js} replacement failed", jsResourceExpected, jsResourceReplaced );
+    assertEquals( "${res:script.js} replacement failed", jsResourceExpected, jsResourceReplaced );
 
     options = new CdfRunJsDashboardWriteOptions( true, false, "localhost:8080", "http" );
     context = this.getContext( dashboardPath, false );
 
     jsResourceReplaced = removeParams( context.replaceTokens( jsResource ) );
-    Assert.assertEquals( "${res:script.js} replacement failed", jsResourceAbsoluteExpected, jsResourceReplaced );
+    assertEquals( "${res:script.js} replacement failed", jsResourceAbsoluteExpected, jsResourceReplaced );
 
     options = new CdfRunJsDashboardWriteOptions( false, false, "localhost:8080", "http" );
     context = this.getContext( dashboardPath, false );
 
     jsResourceReplaced = removeParams( context.replaceTokens( jsResource ) );
-    Assert.assertEquals( "${res:script.js} replacement failed", jsResourceExpected, jsResourceReplaced );
-
-
+    assertEquals( "${res:script.js} replacement failed", jsResourceExpected, jsResourceReplaced );
   }
 
   private PentahoCdfRunJsDashboardWriteContext getContext( String dashboardPath, boolean isSystem ) {

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/properties/CdfRunJsDataSourcePropertyBindingWriterTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/properties/CdfRunJsDataSourcePropertyBindingWriterTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,7 +13,6 @@
 
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.properties;
 
-import junit.framework.TestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,6 +23,8 @@ import pt.webdetails.cdf.dd.model.meta.DashboardType;
 import pt.webdetails.cdf.dd.model.meta.MetaModel;
 import pt.webdetails.cdf.dd.structure.DashboardWcdfDescriptor;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -31,7 +32,7 @@ import static pt.webdetails.cdf.dd.CdeConstants.Writer.DataSource.AttributeName.
 import static pt.webdetails.cdf.dd.CdeConstants.Writer.DataSource.PropertyName.MDX_QUERY;
 import static pt.webdetails.cdf.dd.CdeConstants.Writer.DataSource.PropertyName.STREAMING_TYPE;
 
-public class CdfRunJsDataSourcePropertyBindingWriterTest extends TestCase {
+public class CdfRunJsDataSourcePropertyBindingWriterTest {
 
   private CdfRunJsDataSourcePropertyBindingWriter dataSourcePropertyBindingWriter;
   private StringBuilder out;

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/properties/CdfRunJsPropertyBindingWriterTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cdfrunjs/properties/CdfRunJsPropertyBindingWriterTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,8 +13,6 @@
 
 package pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.properties;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -26,7 +24,10 @@ import pt.webdetails.cdf.dd.model.meta.MetaModel;
 import pt.webdetails.cdf.dd.model.meta.PropertyType;
 import pt.webdetails.cdf.dd.model.meta.PropertyTypeUsage;
 
-public class CdfRunJsPropertyBindingWriterTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class CdfRunJsPropertyBindingWriterTest {
   private CdfRunJsPropertyBindingWriterForTests propertyBindingWriter;
 
   @Before
@@ -93,9 +94,9 @@ public class CdfRunJsPropertyBindingWriterTest extends TestCase {
     try {
       propertyBindingWriter.write( out, null, getPropertyBinding( test ) );
     } catch ( ValidationException e ) {
-      Assert.fail( "ValidationException occurred" );
+      fail( "ValidationException occurred" );
     }
-    Assert.assertEquals( expected, out.toString() );
+    assertEquals( expected, out.toString() );
   }
 
   private PropertyBinding getPropertyBinding( String value ) throws ValidationException {

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cggrunjs/CggRunJsThingWriterFactoryTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/inst/writer/cggrunjs/CggRunJsThingWriterFactoryTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -14,7 +14,6 @@
 package pt.webdetails.cdf.dd.model.inst.writer.cggrunjs;
 
 
-import junit.framework.TestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,10 +24,13 @@ import pt.webdetails.cdf.dd.model.inst.DataSourceComponent;
 import pt.webdetails.cdf.dd.model.inst.GenericComponent;
 import pt.webdetails.cdf.dd.model.meta.GenericComponentType;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
-public class CggRunJsThingWriterFactoryTest extends TestCase {
+public class CggRunJsThingWriterFactoryTest {
 
   private CggRunJsThingWriterFactoryForTest cggRunJsThingWriterFactory;
   private GenericComponentType meta;
@@ -44,17 +46,12 @@ public class CggRunJsThingWriterFactoryTest extends TestCase {
     meta = null;
   }
 
-  @Test
-  public void testNullValueThing() {
+  @Test( expected = IllegalArgumentException.class )
+  public void testNullValueThing() throws Exception {
     cggRunJsThingWriterFactory = new CggRunJsThingWriterFactoryForTest( "" );
-    try {
-      cggRunJsThingWriterFactory.getWriter( null );
-      fail( "IllegalArgumentException should have been thrown" );
-    } catch ( IllegalArgumentException e ) {
-      assertTrue( true );
-    } catch ( UnsupportedThingException e ) {
-      fail( "IllegalArgumentException should have been thrown" );
-    }
+
+    // An IllegalArgumentException should be thrown here
+    cggRunJsThingWriterFactory.getWriter( null );
   }
 
   @Test
@@ -69,8 +66,7 @@ public class CggRunJsThingWriterFactoryTest extends TestCase {
 
       IThingWriter iWriter = cggRunJsThingWriterFactory.getWriter( thing );
       assertTrue( iWriter instanceof CggRunJsGenericComponentWriter );
-      CggRunJsGenericComponentWriter writer = (CggRunJsGenericComponentWriter) iWriter;
-      assertFalse( writer.canWrite() );
+      assertFalse( ((CggRunJsGenericComponentWriter) iWriter).canWrite() );
 
     } catch ( IllegalArgumentException e ) {
       fail( "IllegalArgumentException should not have been thrown" );
@@ -89,11 +85,9 @@ public class CggRunJsThingWriterFactoryTest extends TestCase {
     doReturn( "true" ).when( meta ).tryGetAttributeValue( "cdwSupport", "false" );
 
     try {
-
       IThingWriter iWriter = cggRunJsThingWriterFactory.getWriter( thing );
       assertTrue( iWriter instanceof CggRunJsGenericComponentWriter );
-      CggRunJsGenericComponentWriter writer = (CggRunJsGenericComponentWriter) iWriter;
-      assertTrue( writer.canWrite() );
+      assertTrue( ((CggRunJsGenericComponentWriter) iWriter).canWrite() );
 
     } catch ( IllegalArgumentException e ) {
       fail( "IllegalArgumentException should not have been thrown" );
@@ -110,7 +104,6 @@ public class CggRunJsThingWriterFactoryTest extends TestCase {
     doReturn( KnownThingKind.Component ).when( thing ).getKind();
 
     try {
-
       IThingWriter iWriter = cggRunJsThingWriterFactory.getWriter( thing );
       assertTrue( iWriter instanceof CggRunJsDataSourceComponentWriter );
 
@@ -129,7 +122,6 @@ public class CggRunJsThingWriterFactoryTest extends TestCase {
     doReturn( KnownThingKind.Dashboard ).when( thing ).getKind();
 
     try {
-
       IThingWriter iWriter = cggRunJsThingWriterFactory.getWriter( thing );
       assertTrue( iWriter instanceof CggRunJsDashboardWriter );
 
@@ -140,9 +132,9 @@ public class CggRunJsThingWriterFactoryTest extends TestCase {
     }
   }
 
-  private class CggRunJsThingWriterFactoryForTest extends CggRunJsThingWriterFactory {
+  private static class CggRunJsThingWriterFactoryForTest extends CggRunJsThingWriterFactory {
 
-    private String compId;
+    private final String compId;
 
     public CggRunJsThingWriterFactoryForTest( String id ) {
       this.compId = id;

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/meta/reader/cdexml/XmlComponentTypeReaderTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/meta/reader/cdexml/XmlComponentTypeReaderTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,9 +13,8 @@
 
 package pt.webdetails.cdf.dd.model.meta.reader.cdexml;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
-import org.dom4j.*;
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,9 +22,12 @@ import pt.webdetails.cdf.dd.model.meta.ComponentType;
 import pt.webdetails.cdf.dd.model.meta.CustomComponentType;
 import pt.webdetails.cdf.dd.model.meta.reader.cdexml.fs.XmlFsPluginThingReaderFactory;
 
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
-public class XmlComponentTypeReaderTest extends TestCase {
+
+public class XmlComponentTypeReaderTest {
 
   private static XmlComponentTypeReader xmlComponentTypeReader;
 
@@ -34,7 +36,6 @@ public class XmlComponentTypeReaderTest extends TestCase {
     xmlComponentTypeReader = new XmlAdhocComponentTypeReader(
       CustomComponentType.Builder.class,
       mock( XmlFsPluginThingReaderFactory.class ) );
-
   }
 
   @After
@@ -56,8 +57,8 @@ public class XmlComponentTypeReaderTest extends TestCase {
       .addAttribute( "supportsAMD", "true" )
       .addAttribute( "supportsLegacy", "false" );
     xmlComponentTypeReader.readComponentSupportType( builder, elem );
-    Assert.assertEquals( builder.isSupportsLegacy(), false );
-    Assert.assertEquals( builder.isSupportsAMD(), true );
+    assertFalse( builder.isSupportsLegacy() );
+    assertTrue( builder.isSupportsAMD() );
 
     builder = new CustomComponentType.Builder();
     elem = DocumentHelper.createDocument().addElement( "DesignerComponent" );
@@ -65,8 +66,8 @@ public class XmlComponentTypeReaderTest extends TestCase {
       .addElement( "Implementation" )
       .addAttribute( "supportsAMD", "true" );
     xmlComponentTypeReader.readComponentSupportType( builder, elem );
-    Assert.assertEquals( builder.isSupportsLegacy(), false );
-    Assert.assertEquals( builder.isSupportsAMD(), true );
+    assertFalse( builder.isSupportsLegacy() );
+    assertTrue( builder.isSupportsAMD() );
 
     // supports Legacy
     builder = new CustomComponentType.Builder();
@@ -76,8 +77,8 @@ public class XmlComponentTypeReaderTest extends TestCase {
       .addAttribute( "supportsAMD", "false" )
       .addAttribute( "supportsLegacy", "true" );
     xmlComponentTypeReader.readComponentSupportType( builder, elem );
-    Assert.assertEquals( builder.isSupportsLegacy(), true );
-    Assert.assertEquals( builder.isSupportsAMD(), false );
+    assertTrue( builder.isSupportsLegacy() );
+    assertFalse( builder.isSupportsAMD() );
 
     builder = new CustomComponentType.Builder();
     elem = DocumentHelper.createDocument().addElement( "DesignerComponent" );
@@ -85,8 +86,8 @@ public class XmlComponentTypeReaderTest extends TestCase {
       .addElement( "Implementation" )
       .addAttribute( "supportsLegacy", "true" );
     xmlComponentTypeReader.readComponentSupportType( builder, elem );
-    Assert.assertEquals( builder.isSupportsLegacy(), true );
-    Assert.assertEquals( builder.isSupportsAMD(), false );
+    assertTrue( builder.isSupportsLegacy() );
+    assertFalse( builder.isSupportsAMD() );
 
     // supports both AMD and Legacy
     builder = new CustomComponentType.Builder();
@@ -96,8 +97,8 @@ public class XmlComponentTypeReaderTest extends TestCase {
       .addAttribute( "supportsAMD", "true" )
       .addAttribute( "supportsLegacy", "true" );
     xmlComponentTypeReader.readComponentSupportType( builder, elem );
-    Assert.assertEquals( builder.isSupportsLegacy(), true );
-    Assert.assertEquals( builder.isSupportsAMD(), true );
+    assertTrue( builder.isSupportsLegacy() );
+    assertTrue( builder.isSupportsAMD() );
 
     // empty support type should use default values
     builder = new CustomComponentType.Builder();
@@ -105,7 +106,7 @@ public class XmlComponentTypeReaderTest extends TestCase {
     elem.addElement( "Contents" )
       .addElement( "Implementation" );
     xmlComponentTypeReader.readComponentSupportType( builder, elem );
-    Assert.assertEquals( builder.isSupportsLegacy(), true );
-    Assert.assertEquals( builder.isSupportsAMD(), false );
+    assertTrue( builder.isSupportsLegacy() );
+    assertFalse( builder.isSupportsAMD() );
   }
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/model/meta/reader/cdexml/fs/XmlFsPluginModelReaderTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/model/meta/reader/cdexml/fs/XmlFsPluginModelReaderTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,8 +13,6 @@
 
 package pt.webdetails.cdf.dd.model.meta.reader.cdexml.fs;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.apache.commons.io.FilenameUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,10 +42,16 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-
-public class XmlFsPluginModelReaderTest extends TestCase {
+public class XmlFsPluginModelReaderTest {
 
   private static XmlFsPluginModelReader modelReader;
   private static XmlFsPluginThingReaderFactory factory;
@@ -56,14 +60,14 @@ public class XmlFsPluginModelReaderTest extends TestCase {
   private static final String TEST_DIR = Utils.joinPath( System.getProperty( "user.dir" ), "src/test" );
   private static final String RESOURCE_DIR = Utils.joinPath( TEST_DIR, "resources" );
   private static final String DUMMY_XML =
-      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><DesignerComponent></DesignerComponent>";
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><DesignerComponent></DesignerComponent>";
   private static final String PROPERTIES_MATCHER = "properties";
 
   @Before
   public void setUp() throws Exception {
     mockedReadAccess = mock( IReadAccess.class );
     when( mockedReadAccess.listFiles( anyString(), any( IBasicFileFilter.class ), anyInt() ) ).thenAnswer(
-        new Answer<Object>() {
+      new Answer<Object>() {
         @Override
         public Object answer( InvocationOnMock invocation ) throws Throwable {
           return buildFileList();
@@ -80,7 +84,7 @@ public class XmlFsPluginModelReaderTest extends TestCase {
           return buildReadAccessMock( Utils.joinPath( RESOURCE_DIR, XmlFsPluginModelReader.COMPONENTS_DIR ) );
         } else if ( path.equals( XmlFsPluginModelReader.PROPERTIES_DIR ) ) {
           return buildReadAccessMock( Utils.joinPath( RESOURCE_DIR, XmlFsPluginModelReader.PROPERTIES_DIR ) );
-       } else {
+        } else {
           return mockedReadAccess;
         }
       }
@@ -88,7 +92,7 @@ public class XmlFsPluginModelReaderTest extends TestCase {
     when( mockedContentAccessFactory.getPluginRepositoryReader( anyString() ) ).thenReturn( mockedReadAccess );
 
     IPluginResourceLocationManager mockedPluginResourceLocationManager = mock( IPluginResourceLocationManager.class );
-    List<PathOrigin> pathOrigins = new ArrayList<PathOrigin>();
+    List<PathOrigin> pathOrigins = new ArrayList<>();
     pathOrigins.add( new StaticSystemOrigin( Utils.joinPath( RESOURCE_DIR, XmlFsPluginModelReader.COMPONENTS_DIR ) ) );
     when( mockedPluginResourceLocationManager.getCustomComponentsLocations() ).thenReturn( pathOrigins );
 
@@ -109,18 +113,17 @@ public class XmlFsPluginModelReaderTest extends TestCase {
       List<List<ComponentType>> splitComponentTypes = buildComponentTypes( model.getComponentTypes() );
 
       if ( model.getComponentTypeCount() == 0 ) {
-        Assert.fail( "Couldn't read ComponentTypes" );
+        fail( "Couldn't read ComponentTypes" );
       }
       if ( model.getPropertyTypeCount() == 0 ) {
-        Assert.fail( "Couldn't read PropertyTypes" );
+        fail( "Couldn't read PropertyTypes" );
       }
 
       for ( List<ComponentType> compTypes : splitComponentTypes ) {
         String oldSourcePath = "";
-        String currentPath = "";
         for ( ComponentType comp : compTypes ) {
-          currentPath = comp.getSourcePath().toLowerCase();
-          Assert.assertTrue( currentPath.compareTo( oldSourcePath ) >= 0 );
+          String currentPath = comp.getSourcePath().toLowerCase();
+          assertTrue( currentPath.compareTo( oldSourcePath ) >= 0 );
           oldSourcePath = currentPath;
         }
       }
@@ -128,10 +131,9 @@ public class XmlFsPluginModelReaderTest extends TestCase {
 
       for ( List<PropertyType> propTypes : splitPropertyTypes ) {
         String oldSourcePath = "";
-        String currentPath = "";
         for ( PropertyType prop : propTypes ) {
-          currentPath = prop.getSourcePath().toLowerCase();
-          Assert.assertTrue( currentPath.compareTo( oldSourcePath ) >= 0 );
+          String currentPath = prop.getSourcePath().toLowerCase();
+          assertTrue( currentPath.compareTo( oldSourcePath ) >= 0 );
           oldSourcePath = currentPath;
         }
       }
@@ -157,8 +159,8 @@ public class XmlFsPluginModelReaderTest extends TestCase {
   }
 
   private List<List<ComponentType>> buildComponentTypes( Iterable<ComponentType> componentTypes ) {
-    List<List<ComponentType>> splitComponentTypes = new ArrayList<List<ComponentType>>();
-    List<String> pathOrigins = new ArrayList<String>();
+    List<List<ComponentType>> splitComponentTypes = new ArrayList<>();
+    List<String> pathOrigins = new ArrayList<>();
 
     for ( ComponentType comp : componentTypes ) {
       if ( !pathOrigins.contains( comp.getOrigin().toString() ) ) {
@@ -166,7 +168,7 @@ public class XmlFsPluginModelReaderTest extends TestCase {
       }
     }
     for ( String origin : pathOrigins ) {
-      List<ComponentType> compTypes = new ArrayList<ComponentType>();
+      List<ComponentType> compTypes = new ArrayList<>();
       for ( ComponentType comp : componentTypes ) {
         if ( origin.equals( comp.getOrigin().toString() ) ) {
           compTypes.add( comp );
@@ -185,7 +187,7 @@ public class XmlFsPluginModelReaderTest extends TestCase {
     IBasicFile foo = mock( IBasicFile.class );
     when( foo.getContents() ).thenReturn( buildFileInputStream() );
     when( foo.getFullPath() ).thenReturn( "path/to/foo" );
-    List<IBasicFile> fileList = new ArrayList<IBasicFile>();
+    List<IBasicFile> fileList = new ArrayList<>();
     fileList.add( foo );
     return fileList;
   }
@@ -251,5 +253,4 @@ public class XmlFsPluginModelReaderTest extends TestCase {
       }
     };
   }
-
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/render/CdaRendererTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/render/CdaRendererTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,7 +13,6 @@
 
 package pt.webdetails.cdf.dd.render;
 
-import junit.framework.Assert;
 import org.apache.commons.io.FileUtils;
 import org.json.JSONException;
 import org.junit.After;
@@ -30,6 +29,9 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class CdaRendererTest {
   CdaRenderer cdaRenderer;
@@ -58,46 +60,45 @@ public class CdaRendererTest {
     Document dom = stringToDom( cdaRenderer.render() );
 
     NodeList cDADescriptor = dom.getElementsByTagName( "CDADescriptor" );
-    Assert.assertNotNull( cDADescriptor );
-    Assert.assertTrue( cDADescriptor.getLength() == 1 );
+    assertNotNull( cDADescriptor );
+    assertEquals( 1, cDADescriptor.getLength() );
 
     NodeList dataSources = dom.getElementsByTagName( "DataSources" );
-    Assert.assertNotNull( dataSources );
-    Assert.assertTrue( dataSources.getLength() == 1 );
+    assertNotNull( dataSources );
+    assertEquals( 1, dataSources.getLength() );
 
     NodeList connections = dom.getElementsByTagName( "Connection" );
-    Assert.assertNotNull( connections );
-    Assert.assertTrue( connections.getLength() == 1 );
+    assertNotNull( connections );
+    assertEquals( 1, connections.getLength() );
 
     Node connection = connections.item( 0 );
-    Assert.assertEquals( connection.getAttributes().getNamedItem( "id" ).getNodeValue(), "testQueryFTW" );
+    assertEquals( "testQueryFTW", connection.getAttributes().getNamedItem( "id" ).getNodeValue() );
 
     NodeList dataAccesses = dom.getElementsByTagName( "DataAccess" );
-    Assert.assertNotNull( dataSources );
-    Assert.assertTrue( dataSources.getLength() == 1 );
+    assertNotNull( dataSources );
+    assertEquals( 1, dataSources.getLength() );
 
     Node dataAccess = dataAccesses.item( 0 );
-    Assert.assertEquals( dataAccess.getAttributes().getNamedItem( "access" ).getNodeValue(), "public" );
-    Assert.assertEquals( dataAccess.getAttributes().getNamedItem( "connection" ).getNodeValue(), "testQueryFTW" );
-    Assert.assertEquals( dataAccess.getAttributes().getNamedItem( "id" ).getNodeValue(), "testQueryFTW" );
-    Assert.assertEquals( dataAccess.getAttributes().getNamedItem( "type" ).getNodeValue(), "scriptable" );
+    assertEquals( "public", dataAccess.getAttributes().getNamedItem( "access" ).getNodeValue() );
+    assertEquals( "testQueryFTW", dataAccess.getAttributes().getNamedItem( "connection" ).getNodeValue() );
+    assertEquals( "testQueryFTW", dataAccess.getAttributes().getNamedItem( "id" ).getNodeValue() );
+    assertEquals( "scriptable", dataAccess.getAttributes().getNamedItem( "type" ).getNodeValue() );
     NodeList nodes = dataAccess.getChildNodes();
-    Node el;
     for ( int i = 0; i < nodes.getLength(); i++ ) {
-      el = nodes.item( i );
+      Node el = nodes.item( i );
       switch ( el.getNodeName() ) {
         case "Name":
-          Assert.assertEquals( el.getFirstChild().getNodeValue(), "testQueryFTW" );
+          assertEquals( "testQueryFTW", el.getFirstChild().getNodeValue() );
           break;
         case "Cache":
-          Assert.assertEquals( el.getAttributes().getNamedItem( "duration" ).getNodeValue(), "3600" );
-          Assert.assertEquals( el.getAttributes().getNamedItem( "enabled" ).getNodeValue(), "true" );
+          assertEquals( "3600", el.getAttributes().getNamedItem( "duration" ).getNodeValue() );
+          assertEquals( "true", el.getAttributes().getNamedItem( "enabled" ).getNodeValue() );
           break;
         case "Query":
-          Assert.assertEquals( el.getFirstChild().getNodeType(), CDATASection.CDATA_SECTION_NODE );
-          Assert.assertEquals(
-              el.getFirstChild().getNodeValue(),
-              "import org.pentaho.reporting.engine.classic.core.util"
+          assertEquals( CDATASection.CDATA_SECTION_NODE, el.getFirstChild().getNodeType() );
+          assertEquals(
+            el.getFirstChild().getNodeValue(),
+            "import org.pentaho.reporting.engine.classic.core.util"
               + ".TypedTableModel;\n\n"
               + "String[] columnNames = new String[]{\n"
               + "\"value\",\"name2\"\n"

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/render/cda/CacheTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/render/cda/CacheTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,24 +13,21 @@
 
 package pt.webdetails.cdf.dd.render.cda;
 
-
-import junit.framework.TestCase;
-
 import org.apache.commons.jxpath.JXPathContext;
 import org.json.JSONException;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 import org.junit.Before;
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import java.util.HashMap;
 
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-public class CacheTest extends TestCase {
+public class CacheTest {
 
   private JXPathContext context;
   private Cache cacheRenderer;
@@ -48,7 +45,7 @@ public class CacheTest extends TestCase {
     cache = mock( Element.class );
     key = mock( Element.class );
     doc = mock( Document.class );
-    HashMap<String, Object> map = new HashMap<String, Object>();
+    HashMap<String, Object> map = new HashMap<>();
     map.put( "value", "true" );
     cacheRenderer.setDefinition( map );
 

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/BootstrapColumnRenderTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/BootstrapColumnRenderTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,8 +13,6 @@
 
 package pt.webdetails.cdf.dd.render.layout;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.apache.commons.jxpath.JXPathContext;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,15 +20,16 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
-public class BootstrapColumnRenderTest extends TestCase {
+public class BootstrapColumnRenderTest {
 
   private BootstrapColumnRenderForTest renderForTest;
 
-  private class BootstrapColumnRenderForTest extends BootstrapColumnRender {
+  private static class BootstrapColumnRenderForTest extends BootstrapColumnRender {
 
-    private Map<String, String> properties = new HashMap<String, String>();
+    private final Map<String, String> properties = new HashMap<>();
 
     public BootstrapColumnRenderForTest( JXPathContext context) {
       super( context );
@@ -67,8 +66,7 @@ public class BootstrapColumnRenderTest extends TestCase {
     renderForTest.processProperties();
     String div = renderForTest.renderStart();
 
-    Assert.assertEquals( "<div class='col-xs-12'><div >", div );
-
+    assertEquals( "<div class='col-xs-12'><div >", div );
   }
 
   @Test
@@ -79,7 +77,7 @@ public class BootstrapColumnRenderTest extends TestCase {
 
     String div = renderForTest.renderStart();
 
-    Assert.assertEquals( "<div class='col-xs-5'><div >", div );
+    assertEquals( "<div class='col-xs-5'><div >", div );
   }
 
   @Test
@@ -90,7 +88,7 @@ public class BootstrapColumnRenderTest extends TestCase {
 
     String div = renderForTest.renderStart();
 
-    Assert.assertEquals( "<div class='col-xs-12'><div  class='span-6 ' >", div );
+    assertEquals( "<div class='col-xs-12'><div  class='span-6 ' >", div );
   }
 
   @Test
@@ -102,13 +100,12 @@ public class BootstrapColumnRenderTest extends TestCase {
 
     String div = renderForTest.renderStart();
 
-    Assert.assertEquals( "<div class='col-xs-5'><div  class='span-6 ' >", div );
+    assertEquals( "<div class='col-xs-5'><div  class='span-6 ' >", div );
   }
 
   @Test
   public void testRenderClose() {
     String div = renderForTest.renderClose();
-    Assert.assertEquals( "</div></div>", div );
+    assertEquals( "</div></div>", div );
   }
-
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/BootstrapPanelBodyRenderTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/BootstrapPanelBodyRenderTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,14 +13,14 @@
 
 package pt.webdetails.cdf.dd.render.layout;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.apache.commons.jxpath.JXPathContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class BootstrapPanelBodyRenderTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class BootstrapPanelBodyRenderTest {
 
   private BootstrapPanelBodyRender renderForTest;
 
@@ -35,14 +35,13 @@ public class BootstrapPanelBodyRenderTest extends TestCase {
   public void testRenderStart() {
     String div = renderForTest.renderStart();
 
-    Assert.assertEquals( "<div  class='panel-body ' >", div );
+    assertEquals( "<div  class='panel-body ' >", div );
   }
 
   @Test
   public void testRenderClose() {
     String div = renderForTest.renderClose();
 
-    Assert.assertEquals( "</div>", div );
+    assertEquals( "</div>", div );
   }
-
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/BootstrapPanelFooterRenderTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/BootstrapPanelFooterRenderTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,14 +13,14 @@
 
 package pt.webdetails.cdf.dd.render.layout;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.apache.commons.jxpath.JXPathContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class BootstrapPanelFooterRenderTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class BootstrapPanelFooterRenderTest {
 
   private BootstrapPanelFooterRender renderForTest;
 
@@ -35,14 +35,13 @@ public class BootstrapPanelFooterRenderTest extends TestCase {
   public void testRenderStart() {
     String div = renderForTest.renderStart();
 
-    Assert.assertEquals( "<div  class='panel-footer ' >", div );
+    assertEquals( "<div  class='panel-footer ' >", div );
   }
 
   @Test
   public void testRenderClose() {
     String div = renderForTest.renderClose();
 
-    Assert.assertEquals( "</div>", div );
+    assertEquals( "</div>", div );
   }
-
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/BootstrapPanelHeaderRenderTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/BootstrapPanelHeaderRenderTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,14 +13,14 @@
 
 package pt.webdetails.cdf.dd.render.layout;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.apache.commons.jxpath.JXPathContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class BootstrapPanelHeaderRenderTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class BootstrapPanelHeaderRenderTest {
 
   private BootstrapPanelHeaderRender renderForTest;
 
@@ -35,14 +35,13 @@ public class BootstrapPanelHeaderRenderTest extends TestCase {
   public void testRenderStart() {
     String div = renderForTest.renderStart();
 
-    Assert.assertEquals( "<div  class='panel-heading ' >", div );
+    assertEquals( "<div  class='panel-heading ' >", div );
   }
 
   @Test
   public void testRenderClose() {
     String div = renderForTest.renderClose();
 
-    Assert.assertEquals( "</div>", div );
+    assertEquals( "</div>", div );
   }
-
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/BootstrapPanelRenderTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/BootstrapPanelRenderTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,18 +13,18 @@
 
 package pt.webdetails.cdf.dd.render.layout;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.apache.commons.jxpath.JXPathContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class BootstrapPanelRenderTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class BootstrapPanelRenderTest {
 
   private BootstrapPanelRenderForTest renderForTest;
 
-  private class BootstrapPanelRenderForTest extends BootstrapPanelRender {
+  private static class BootstrapPanelRenderForTest extends BootstrapPanelRender {
 
     private String bootstrapPanelStyle = "";
 
@@ -53,7 +53,7 @@ public class BootstrapPanelRenderTest extends TestCase {
     renderForTest.processProperties();
     String div = renderForTest.renderStart();
 
-    Assert.assertEquals( "<div  class='panel ' >", div );
+    assertEquals( "<div  class='panel ' >", div );
   }
 
   @Test
@@ -62,13 +62,12 @@ public class BootstrapPanelRenderTest extends TestCase {
     renderForTest.processProperties();
     String div = renderForTest.renderStart();
 
-    Assert.assertEquals( "<div  class='panel panel-info ' >", div );
+    assertEquals( "<div  class='panel panel-info ' >", div );
   }
 
   @Test
   public void testRenderClose() {
     String div = renderForTest.renderClose();
-    Assert.assertEquals( "</div>", div );
+    assertEquals( "</div>", div );
   }
-
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/ColumnRenderTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/ColumnRenderTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,18 +13,18 @@
 
 package pt.webdetails.cdf.dd.render.layout;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.apache.commons.jxpath.JXPathContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class ColumnRenderTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class ColumnRenderTest {
 
   private ColumnRenderForTest renderForTest;
 
-  private class ColumnRenderForTest extends ColumnRender {
+  private static class ColumnRenderForTest extends ColumnRender {
 
     String testRenderType;
 
@@ -60,8 +60,7 @@ public class ColumnRenderTest extends TestCase {
      renderForTest.addColSpan( "5" );
      String div = renderForTest.renderStart();
 
-     Assert.assertEquals( "<div  class='col-md-5 ' >", div );
-
+     assertEquals( "<div  class='col-md-5 ' >", div );
    }
 
   @Test
@@ -70,7 +69,6 @@ public class ColumnRenderTest extends TestCase {
     renderForTest.addColSpan( "5" );
     String div = renderForTest.renderStart();
 
-    Assert.assertEquals( "<div  class='span-5 ' >", div );
-
+    assertEquals( "<div  class='span-5 ' >", div );
   }
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/FreeFormRenderTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/FreeFormRenderTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,18 +13,18 @@
 
 package pt.webdetails.cdf.dd.render.layout;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.apache.commons.jxpath.JXPathContext;
 import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class FreeFormRenderTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class FreeFormRenderTest {
 
   private FreeFormRenderForTest renderForTest;
-  private class FreeFormRenderForTest extends FreeFormRender {
+  private static class FreeFormRenderForTest extends FreeFormRender {
 
     private String properties;
     public FreeFormRenderForTest( JXPathContext context ) {
@@ -44,7 +44,6 @@ public class FreeFormRenderTest extends TestCase {
     private void setPropertyBag( String css ) {
       getPropertyBag().addClass( css );
     }
-
   }
 
   @Before
@@ -59,7 +58,7 @@ public class FreeFormRenderTest extends TestCase {
   public void testRenderStartWithTagOnly() throws JSONException {
     String select = renderForTest.renderStart();
 
-    Assert.assertEquals( "<select >", select );
+    assertEquals( "<select >", select );
   }
 
   @Test
@@ -67,7 +66,7 @@ public class FreeFormRenderTest extends TestCase {
     renderForTest.setProperties( "[[\"arg1\",\"value1\"],[\"arg2\",\"value2\"]]" );
     String select = renderForTest.renderStart();
 
-    Assert.assertEquals( "<select  arg1='value1' arg2='value2'>", select );
+    assertEquals( "<select  arg1='value1' arg2='value2'>", select );
   }
 
   @Test
@@ -76,7 +75,7 @@ public class FreeFormRenderTest extends TestCase {
         + "['arg2', \"{{[ 'value21', 'value22']}}\"]]" );
     String select = renderForTest.renderStart();
 
-    Assert.assertEquals( "<select  arg1='{{[ \"value11\", \"value12\"]}}' arg2=\"{{[ 'value21', 'value22']}}\">",
+    assertEquals( "<select  arg1='{{[ \"value11\", \"value12\"]}}' arg2=\"{{[ 'value21', 'value22']}}\">",
         select );
   }
 
@@ -85,8 +84,7 @@ public class FreeFormRenderTest extends TestCase {
     renderForTest.setPropertyBag( "clear" );
     String select = renderForTest.renderStart();
 
-
-    Assert.assertEquals( "<select  class='clear ' >", select );
+    assertEquals( "<select  class='clear ' >", select );
   }
 
   @Test
@@ -95,13 +93,13 @@ public class FreeFormRenderTest extends TestCase {
     renderForTest.setProperties( "[[\"arg1\",\"value1\"],[\"arg2\",\"value2\"]]" );
     String select = renderForTest.renderStart();
 
-    Assert.assertEquals( "<select  class='clear '  arg1='value1' arg2='value2'>", select );
+    assertEquals( "<select  class='clear '  arg1='value1' arg2='value2'>", select );
   }
 
   @Test
   public void testRenderClose() {
     String select = renderForTest.renderClose();
 
-    Assert.assertEquals( "</select>", select );
+    assertEquals( "</select>", select );
   }
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/ResourceRenderTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/render/layout/ResourceRenderTest.java
@@ -1,12 +1,25 @@
+/*!
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+
 package pt.webdetails.cdf.dd.render.layout;
 
 import org.apache.commons.jxpath.JXPathContext;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import pt.webdetails.cdf.dd.CdeConstants;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 public class ResourceRenderTest {
@@ -23,15 +36,13 @@ public class ResourceRenderTest {
     // CSS file
     when( resourceRender.getPropertyString( CdeConstants.RESOURCE_FILE ) ).thenReturn( "test.css" );
     when( resourceRender.getPropertyString( CdeConstants.RESOURCE_TYPE ) ).thenReturn( CdeConstants.CSS );
-    Assert
-      .assertEquals( resourceRender.renderStart(), "<link rel=\"stylesheet\" type=\"text/css\" href=\"test.css\" />" );
+    assertEquals( "<link rel=\"stylesheet\" type=\"text/css\" href=\"test.css\" />", resourceRender.renderStart() );
 
     // JS file
     when( resourceRender.getPropertyString( CdeConstants.RESOURCE_FILE ) ).thenReturn( "test.js" );
     when( resourceRender.getPropertyString( CdeConstants.RESOURCE_TYPE ) ).thenReturn( CdeConstants.JAVASCRIPT );
-    Assert
-      .assertEquals( resourceRender.renderStart(), "<script language=\"javascript\" type=\"text/javascript\" "
-        + "src=\"test.js\"></script>" );
+    assertEquals( "<script language=\"javascript\" type=\"text/javascript\" src=\"test.js\"></script>",
+      resourceRender.renderStart() );
 
     // clear previous return values
     when( resourceRender.getPropertyString( CdeConstants.RESOURCE_FILE ) ).thenReturn( "" );
@@ -39,14 +50,12 @@ public class ResourceRenderTest {
     // CSS code snippet
     when( resourceRender.getPropertyString( CdeConstants.RESOURCE_CODE ) ).thenReturn( "div {color: inherit;}" );
     when( resourceRender.getPropertyString( CdeConstants.RESOURCE_TYPE ) ).thenReturn( CdeConstants.CSS );
-    Assert
-      .assertEquals( resourceRender.renderStart(), "<style>\n<!--\ndiv {color: inherit;}\n-->\n</style>" );
+    assertEquals( "<style>\n<!--\ndiv {color: inherit;}\n-->\n</style>", resourceRender.renderStart() );
 
     // JS code snippet
     when( resourceRender.getPropertyString( CdeConstants.RESOURCE_CODE ) ).thenReturn( "(function() { return; })();" );
     when( resourceRender.getPropertyString( CdeConstants.RESOURCE_TYPE ) ).thenReturn( CdeConstants.JAVASCRIPT );
-    Assert
-      .assertEquals( resourceRender.renderStart(), "<script language=\"javascript\" type=\"text/javascript\">\n"
-        + "(function() { return; })();\n</script>" );
+    assertEquals( "<script language=\"javascript\" type=\"text/javascript\">\n(function() { return; })();\n</script>",
+      resourceRender.renderStart() );
   }
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/structure/Olap4jDatasourceStructureTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/structure/Olap4jDatasourceStructureTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -12,8 +12,6 @@
  */
 
 package pt.webdetails.cdf.dd.structure;
-
-import junit.framework.Assert;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
@@ -35,6 +33,12 @@ import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public class Olap4jDatasourceStructureTest {
 
   private static final Log logger = LogFactory.getLog( Olap4jDatasourceStructureTest.class );
@@ -45,7 +49,7 @@ public class Olap4jDatasourceStructureTest {
   /**
    * map that holds some values we can validate against the generated cda datasource
    */
-  private Map validationPropertyMap = new HashMap();
+  private final Map<String, String> validationPropertyMap = new HashMap<>();
 
   private String cdfdeContent = StringUtils.EMPTY;
   private String cdaDatasourceDefinitions = StringUtils.EMPTY;
@@ -65,19 +69,19 @@ public class Olap4jDatasourceStructureTest {
     // we mock this by loading the content from a previously saved .cdfde file
     cdfdeContent = FileUtils.readFileToString( new File( CDFDE_FILE ) );
 
-    Assert.assertTrue( !StringUtils.isEmpty( cdfdeContent ) );
+    assertFalse( StringUtils.isEmpty( cdfdeContent ) );
 
     // we mock the cda interplugin call to fetch datasource definitions
     // by loading the content from a previously saved .js file
     cdaDatasourceDefinitions = FileUtils.readFileToString( new File( CDA_DATASOURCE_DEFINITIONS ) );
 
-    Assert.assertTrue( !StringUtils.isEmpty( cdaDatasourceDefinitions ) );
+    assertFalse( StringUtils.isEmpty( cdaDatasourceDefinitions ) );
 
-    validationPropertyMap.put( "JdbcUser" , "pentaho_user" );
-    validationPropertyMap.put( "JdbcPassword" , "password" );
-    validationPropertyMap.put( "Jdbc" , "jdbc:hsqldb:hsql://localhost:9001/Sampledata" );
-    validationPropertyMap.put( "JdbcDriver" , "org.hsqldb.jdbcDriver" );
-    validationPropertyMap.put( "Catalog" , "mondrian:/SteelWheels" );
+    validationPropertyMap.put( "JdbcUser", "pentaho_user" );
+    validationPropertyMap.put( "JdbcPassword", "password" );
+    validationPropertyMap.put( "Jdbc", "jdbc:hsqldb:hsql://localhost:9001/Sampledata" );
+    validationPropertyMap.put( "JdbcDriver", "org.hsqldb.jdbcDriver" );
+    validationPropertyMap.put( "Catalog", "mondrian:/SteelWheels" );
   }
 
   @Test
@@ -106,15 +110,15 @@ public class Olap4jDatasourceStructureTest {
 
       logger.debug( "cdaContentAsString ->\n" + cdaContentAsString );
 
-      Assert.assertTrue( !StringUtils.isEmpty( cdaContentAsString ) );
+      assertFalse( StringUtils.isEmpty( cdaContentAsString ) );
 
       // this is the .cda file content ( that would have been saved / stored )
       Document dom = stringToDom( cdaContentAsString );
 
       NodeList nodes = dom.getElementsByTagName( "Property" );
 
-      Assert.assertNotNull( nodes );
-      Assert.assertTrue( nodes.getLength() > 0 );
+      assertNotNull( nodes );
+      assertTrue( nodes.getLength() > 0 );
 
       logger.info( "Document DataSources/Connection/Property nodes length: " + nodes.getLength() );
 
@@ -127,11 +131,11 @@ public class Olap4jDatasourceStructureTest {
 
         logger.info( "name=" + propName + " , value=" + propValue );
 
-        Assert.assertTrue( validationPropertyMap.get( propName ).equals( propValue ) );
+        assertEquals( propValue, validationPropertyMap.get( propName ) );
       }
     } catch ( Exception e ) {
       logger.error( e );
-      Assert.fail( e.getMessage() );
+      fail( e.getMessage() );
     }
   }
 

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/util/GenericBasicFileFilterTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/util/GenericBasicFileFilterTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -15,15 +15,15 @@ package pt.webdetails.cdf.dd.util;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import pt.webdetails.cpf.repository.api.IBasicFile;
 import pt.webdetails.cpf.repository.api.IBasicFileFilter;
 
 import java.io.IOException;
 import java.io.InputStream;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class GenericBasicFileFilterTest {
 
@@ -35,12 +35,6 @@ public class GenericBasicFileFilterTest {
 
   protected static final String NOT_ACCEPTED_FILENAME = "some_other_name";
   protected static final String NOT_ACCEPTED_EXTENSION = ".gif";
-
-
-  @Before
-  public void setUp() {
-    /* do nothing */
-  }
 
   /**
    * This tests that the file is properly accepted because of having both and accepted filename and an accepted file
@@ -55,7 +49,7 @@ public class GenericBasicFileFilterTest {
 
     IBasicFileFilter filter = new GenericBasicFileFilter( ACCEPTED_FILENAME, ACCEPTED_EXTENSIONS );
 
-    Assert.assertTrue( filter.accept( testFile ) );
+    assertTrue( filter.accept( testFile ) );
   }
 
   /**
@@ -71,7 +65,7 @@ public class GenericBasicFileFilterTest {
 
     IBasicFileFilter filter = new GenericBasicFileFilter( ACCEPTED_FILENAME, new String[] { } );
 
-    Assert.assertTrue( filter.accept( testFile ) );
+    assertTrue( filter.accept( testFile ) );
   }
 
   /**
@@ -87,7 +81,7 @@ public class GenericBasicFileFilterTest {
 
     IBasicFileFilter filter = new GenericBasicFileFilter( ACCEPTED_FILENAME, new String[] { } );
 
-    Assert.assertTrue( filter.accept( testFile ) );
+    assertTrue( filter.accept( testFile ) );
   }
 
   /**
@@ -103,7 +97,7 @@ public class GenericBasicFileFilterTest {
 
     IBasicFileFilter filter = new GenericBasicFileFilter( null, ACCEPTED_EXTENSIONS );
 
-    Assert.assertTrue( filter.accept( testFile ) );
+    assertTrue( filter.accept( testFile ) );
   }
 
   /**
@@ -119,8 +113,7 @@ public class GenericBasicFileFilterTest {
 
     IBasicFileFilter filter = new GenericBasicFileFilter( ACCEPTED_FILENAME, ACCEPTED_EXTENSIONS );
 
-    Assert.assertTrue( !filter.accept( testFile ) );
-
+    assertFalse( filter.accept( testFile ) );
   }
 
   /**
@@ -136,8 +129,7 @@ public class GenericBasicFileFilterTest {
 
     IBasicFileFilter filter = new GenericBasicFileFilter( ACCEPTED_FILENAME, ACCEPTED_EXTENSIONS );
 
-    Assert.assertTrue( !filter.accept( testFile ) );
-
+    assertFalse( filter.accept( testFile ) );
   }
 
   /**
@@ -152,7 +144,7 @@ public class GenericBasicFileFilterTest {
 
     IBasicFileFilter filter = new GenericBasicFileFilter( ACCEPTED_FILENAME, ACCEPTED_EXTENSIONS, acceptDirectories );
 
-    Assert.assertTrue( filter.accept( testFolder ) );
+    assertTrue( filter.accept( testFolder ) );
   }
 
   @Test
@@ -164,20 +156,13 @@ public class GenericBasicFileFilterTest {
 
     IBasicFileFilter filter = new GenericBasicFileFilter( ACCEPTED_FILENAME, ACCEPTED_EXTENSIONS, acceptDirectories );
 
-    Assert.assertTrue( !filter.accept( testFolder ) );
-
+    assertFalse( filter.accept( testFolder ) );
   }
 
-  @After
-  public void tearDown() {
-    /* do nothing */
-  }
+  protected static class DummyBasicFile implements IBasicFile {
 
-
-  protected class DummyBasicFile implements IBasicFile {
-
-    private String path;
-    private boolean directory;
+    private final String path;
+    private final boolean directory;
 
     public DummyBasicFile( String fullPath ) throws IllegalArgumentException {
       this.path = fullPath;
@@ -208,5 +193,4 @@ public class GenericBasicFileFilterTest {
       return directory;
     }
   }
-
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/util/GenericFileAndDirectoryFilterTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/util/GenericFileAndDirectoryFilterTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,10 +13,12 @@
 
 package pt.webdetails.cdf.dd.util;
 
-import org.junit.Assert;
 import org.junit.Test;
 import pt.webdetails.cpf.repository.api.IBasicFile;
 import pt.webdetails.cpf.repository.api.IBasicFileFilter;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class GenericFileAndDirectoryFilterTest extends GenericBasicFileFilterTest {
 
@@ -53,7 +55,7 @@ public class GenericFileAndDirectoryFilterTest extends GenericBasicFileFilterTes
 
     // this directory should now be accepted because it is contained in the DIRECTORIES and we are doing a
     // FILTER_IN logic ( white-list )
-    Assert.assertTrue( filter.accept( testFolder ) );
+    assertTrue( filter.accept( testFolder ) );
   }
 
   @Test
@@ -80,7 +82,7 @@ public class GenericFileAndDirectoryFilterTest extends GenericBasicFileFilterTes
 
     // this directory should *not* be accepted, because it is contained in the DIRECTORIES and we are doing a
     // FILTER_OUT logic ( black-list )
-    Assert.assertTrue( !filter.accept( testFolder ) );
+    assertFalse( filter.accept( testFolder ) );
   }
 
   @Test
@@ -106,7 +108,7 @@ public class GenericFileAndDirectoryFilterTest extends GenericBasicFileFilterTes
 
     // this directory should be accepted, because it is *not* contained in the DIRECTORIES and we are doing a
     // FILTER_OUT logic ( black-list )
-    Assert.assertTrue( filter.accept( testFolder ) );
+    assertTrue( filter.accept( testFolder ) );
   }
 
   @Test
@@ -133,8 +135,6 @@ public class GenericFileAndDirectoryFilterTest extends GenericBasicFileFilterTes
 
     // this directory should *not* be accepted, because it is not contained in the DIRECTORIES and we are doing a
     // FILTER_IN logic ( white-list )
-    Assert.assertTrue( !filter.accept( testFolder ) );
+    assertFalse( filter.accept( testFolder ) );
   }
-
-
 }

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/util/JsonUtilsTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/util/JsonUtilsTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,7 +13,6 @@
 
 package pt.webdetails.cdf.dd.util;
 
-import junit.framework.Assert;
 import org.apache.commons.jxpath.JXPathContext;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -23,6 +22,8 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 public class JsonUtilsTest {
 
@@ -34,18 +35,17 @@ public class JsonUtilsTest {
   public void testToJXPathContext() throws JSONException {
     JXPathContext jxPathContext = JsonUtils.toJXPathContext( createTestJSON() );
 
-    Assert.assertEquals( "simple", jxPathContext.getValue( "/property1" ) );
-    Assert.assertEquals( "simple", jxPathContext.getValue( "//property2" ) );
-    Assert.assertEquals( "test", jxPathContext.getValue( "//property4" ) );
-    Assert.assertEquals( "test", jxPathContext.getValue( "//property4" ) );
+    assertEquals( "simple", jxPathContext.getValue( "/property1" ) );
+    assertEquals( "simple", jxPathContext.getValue( "//property2" ) );
+    assertEquals( "test", jxPathContext.getValue( "//property4" ) );
+    assertEquals( "test", jxPathContext.getValue( "//property4" ) );
 
     ArrayList<Object> array = (ArrayList<Object>) jxPathContext.getValue( "//array2" );
-    Assert.assertEquals( "inside json", array.get( 0 ) );
-    Assert.assertEquals( 3, array.get( 1 ) );
+    assertEquals( "inside json", array.get( 0 ) );
+    assertEquals( 3, array.get( 1 ) );
     Map<String, Object> map = (Map<String, Object>) array.get( 2 );
-    Assert.assertEquals("property4", map.keySet().toArray()[0] );
-    Assert.assertEquals("test", map.get( "property4" ) );
-
+    assertEquals("property4", map.keySet().toArray()[0] );
+    assertEquals("test", map.get( "property4" ) );
   }
 
   private JSONObject createTestJSON() throws JSONException {

--- a/core/impl/src/test/java/pt/webdetails/cdf/dd/util/XPathUtilsTest.java
+++ b/core/impl/src/test/java/pt/webdetails/cdf/dd/util/XPathUtilsTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,20 +13,21 @@
 
 package pt.webdetails.cdf.dd.util;
 
-import junit.framework.Assert;
 import org.apache.commons.jxpath.JXPathContext;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import pt.webdetails.cdf.dd.structure.DashboardWcdfDescriptor;
 
+import static org.junit.Assert.assertEquals;
+
 public class XPathUtilsTest {
 
-  private final String WCDF_AUTHOR = "dummyAuthor";
-  private final String WCDF_DESCRIPTION = "dummyDescription";
-  private final String WCDF_RENDERER_TYPE = "dummyRendererType";
-  private final String WCDF_STYLE = "dummyStyle";
-  private final String WCDF_TITLE = "dummyTitle";
+  private static final String WCDF_AUTHOR = "dummyAuthor";
+  private static final String WCDF_DESCRIPTION = "dummyDescription";
+  private static final String WCDF_RENDERER_TYPE = "dummyRendererType";
+  private static final String WCDF_STYLE = "dummyStyle";
+  private static final String WCDF_TITLE = "dummyTitle";
 
   @Test
   public void testGetStringValue() throws JSONException {
@@ -35,12 +36,12 @@ public class XPathUtilsTest {
     json.put( "settings", getDummyDashboardWcdfDescriptor().toJSON() );
     JXPathContext node = JsonUtils.toJXPathContext( json );
 
-    Assert.assertEquals( XPathUtils.getStringValue( node, "//author" ), WCDF_AUTHOR );
-    Assert.assertEquals( XPathUtils.getStringValue( node, "//description" ), WCDF_DESCRIPTION );
-    Assert.assertEquals( XPathUtils.getStringValue( node, "//rendererType" ), WCDF_RENDERER_TYPE );
-    Assert.assertEquals( XPathUtils.getStringValue( node, "//style" ), WCDF_STYLE );
-    Assert.assertEquals( XPathUtils.getStringValue( node, "//title" ), WCDF_TITLE );
-    Assert.assertEquals( XPathUtils.getStringValue( node, "//widget" ), "false" );
+    assertEquals( WCDF_AUTHOR, XPathUtils.getStringValue( node, "//author" ) );
+    assertEquals( WCDF_DESCRIPTION, XPathUtils.getStringValue( node, "//description" ) );
+    assertEquals( WCDF_RENDERER_TYPE, XPathUtils.getStringValue( node, "//rendererType" ) );
+    assertEquals( WCDF_STYLE, XPathUtils.getStringValue( node, "//style" ) );
+    assertEquals( WCDF_TITLE, XPathUtils.getStringValue( node, "//title" ) );
+    assertEquals( "false", XPathUtils.getStringValue( node, "//widget" ) );
   }
 
   private DashboardWcdfDescriptor getDummyDashboardWcdfDescriptor() {

--- a/osgi/impl/src/test/java/org/pentaho/ctools/cde/cache/impl/CacheTest.java
+++ b/osgi/impl/src/test/java/org/pentaho/ctools/cde/cache/impl/CacheTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2018-2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,12 +13,8 @@
 
 package org.pentaho.ctools.cde.cache.impl;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -27,7 +23,13 @@ import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboa
 import pt.webdetails.cpf.exceptions.InitializationException;
 import pt.webdetails.cpf.repository.api.IReadAccess;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -43,7 +45,7 @@ public class CacheTest {
   public static void beforeAll() throws Exception {
     mockedReadAccess = mock( IReadAccess.class );
     when( mockedReadAccess.getFileInputStream( anyString() ) )
-      .thenReturn( new FileInputStream( new File( EHCACHE_FILE_PATH.replace( "/", File.separator ) ) ) );
+      .thenReturn( new FileInputStream( EHCACHE_FILE_PATH.replace( "/", File.separator ) ) );
     cache = new Cache( mockedReadAccess );
   }
 
@@ -55,7 +57,7 @@ public class CacheTest {
 
   @Before
   public void setUp() {
-    this.cache.removeAll();
+    cache.removeAll();
     key = new DashboardCacheKey("mock", "", false, false, "", "" );
     value = new CdfRunJsDashboardWriteResult.Builder().build();
   }
@@ -66,32 +68,20 @@ public class CacheTest {
     key = null;
   }
 
-  @Test
-  public void testInitializationFailLoadConfiguration() {
-    try{
-      when( mockedReadAccess.getFileInputStream( anyString() ) )
-        .thenThrow( new IOException( "mocked IOException" ) );
-      new Cache( mockedReadAccess );
-      Assert.fail( "InitializationException not thrown" );
-    } catch ( InitializationException e ) {
-      Assert.assertEquals( "Failed to load the cache configuration file: ehcache.xml", e.getMessage() );
-    } catch ( Exception e ) {
-      Assert.fail( "InitializationException not thrown" );
-    }
+  @Test( expected = InitializationException.class )
+  public void testInitializationFailLoadConfiguration() throws Exception {
+    when( mockedReadAccess.getFileInputStream( anyString() ) )
+      .thenThrow( new IOException( "mocked IOException" ) );
+    new Cache( mockedReadAccess );
+    fail( "InitializationException not thrown" );
   }
 
-  @Test
-  public void testInitializationFailLoadCacheManager() {
-    try {
-      when( mockedReadAccess.getFileInputStream( anyString() ) )
-        .thenReturn( null );
-      new Cache( mockedReadAccess );
-      Assert.fail( "InitializationException not thrown" );
-    } catch ( InitializationException e ) {
-      Assert.assertEquals( "Failed to create the cache manager.", e.getMessage() );
-    } catch ( Exception e ) {
-      Assert.fail( "InitializationException not thrown" );
-    }
+  @Test( expected = InitializationException.class )
+  public void testInitializationFailLoadCacheManager() throws Exception {
+    when( mockedReadAccess.getFileInputStream( anyString() ) )
+      .thenReturn( null );
+    new Cache( mockedReadAccess );
+    fail( "InitializationException not thrown" );
   }
 
   @Test
@@ -117,7 +107,7 @@ public class CacheTest {
     cache.put( key, value );
     assertEquals( value, cache.get( key ) );
     cache.remove( key );
-    assertEquals( null, cache.get( key ) );
+    assertNull( cache.get( key ) );
   }
 
   @Test

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/DashboardDesignerContentGeneratorTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/DashboardDesignerContentGeneratorTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2019-2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -20,6 +20,7 @@ import org.pentaho.platform.api.engine.IPluginResourceLoader;
 import org.pentaho.platform.engine.core.solution.SimpleParameterProvider;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.web.http.request.HttpRequestParameterProvider;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -46,6 +47,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith( PowerMockRunner.class )
 @PrepareForTest( { PentahoSystem.class, Utils.class, XSSHelper.class, CdeEnvironment.class } )
+@PowerMockIgnore({"jdk.internal.reflect.*"})
 public class DashboardDesignerContentGeneratorTest {
 
   private static final String PLUGIN_NAME = "pentaho-cdf-dd";

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/DatasourcesApiTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/DatasourcesApiTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,10 +13,11 @@
 
 package pt.webdetails.cdf.dd.api;
 
-import junit.framework.Assert;
 import org.json.JSONException;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class DatasourcesApiTest {
 
@@ -33,8 +34,6 @@ public class DatasourcesApiTest {
     DatasourcesApiForTesting datasourcesApi = new DatasourcesApiForTesting();
     String actualResult = datasourcesApi.listCdaSources( DASHBOARD );
 
-    Assert.assertEquals( EXPECTED, actualResult );
-
+    assertEquals( EXPECTED, actualResult );
   }
-
 }

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/EditorApiTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/EditorApiTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,19 +13,22 @@
 
 package pt.webdetails.cdf.dd.api;
 
-import junit.framework.Assert;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class EditorApiTest {
 
@@ -44,11 +47,7 @@ public class EditorApiTest {
   public void beforeEach() throws Exception {
     editorApi = new EditorApiForTesting();
     mockHelper = mock( XSSHelper.class );
-    when( mockHelper.escape( any() ) ).thenAnswer( new Answer<Object>() {
-      @Override public Object answer( InvocationOnMock invocation ) throws Throwable {
-        return invocation.getArguments()[ 0 ];
-      }
-    } );
+    when( mockHelper.escape( any() ) ).thenAnswer( invocation -> invocation.getArguments()[ 0 ] );
     XSSHelper.setInstance( mockHelper );
   }
 
@@ -87,10 +86,10 @@ public class EditorApiTest {
     editorApi.setSavedFile( false );
     String noAccessSaveFalse = editorApi.createFile( FAKE_PATH + FAKE_FILE, "", null );
 
-    Assert.assertEquals( MESSAGE_OK, hasAccessSaveTrue );
-    Assert.assertEquals( MESSAGE_ERROR, hasAccessSaveFalse );
-    Assert.assertEquals( MESSAGE_NO_PERMISSIONS, noAccessSaveTrue );
-    Assert.assertEquals( MESSAGE_NO_PERMISSIONS, noAccessSaveFalse );
+    assertEquals( MESSAGE_OK, hasAccessSaveTrue );
+    assertEquals( MESSAGE_ERROR, hasAccessSaveFalse );
+    assertEquals( MESSAGE_NO_PERMISSIONS, noAccessSaveTrue );
+    assertEquals( MESSAGE_NO_PERMISSIONS, noAccessSaveFalse );
     verify( mockHelper, atLeastOnce() ).escape( anyString() );
   }
 

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/ResourcesApiTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/ResourcesApiTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2019-2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -27,6 +27,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 import org.pentaho.platform.api.engine.IPluginResourceLoader;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import pt.webdetails.cdf.dd.CdeConstants;
@@ -37,6 +38,7 @@ import javax.ws.rs.core.Response;
 
 @RunWith( PowerMockRunner.class )
 @PrepareForTest( { PentahoSystem.class, Utils.class } )
+@PowerMockIgnore({"jdk.internal.reflect.*"})
 public class ResourcesApiTest {
 
   private ResourcesApi resourcesApi;

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/cache/impl/CacheTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/cache/impl/CacheTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2018-2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,24 +13,24 @@
 
 package pt.webdetails.cdf.dd.cache.impl;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import pt.webdetails.cdf.dd.CdeEnvironmentForTests;
 import pt.webdetails.cdf.dd.DashboardCacheKey;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteResult;
 import pt.webdetails.cpf.exceptions.InitializationException;
 import pt.webdetails.cpf.repository.api.IContentAccessFactory;
 import pt.webdetails.cpf.repository.api.IReadAccess;
-import pt.webdetails.cpf.repository.api.IUserContentAccess;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -48,7 +48,7 @@ public class CacheTest {
   public static void beforeAll() throws Exception {
     mockedReadAccess = mock( IReadAccess.class );
     when( mockedReadAccess.getFileInputStream( any() ) )
-      .thenReturn( new FileInputStream( new File( EHCACHE_FILE_PATH.replace( "/", File.separator ) ) ) );
+      .thenReturn( new FileInputStream( EHCACHE_FILE_PATH.replace( "/", File.separator ) ) );
     contentAccessFactory = mock( IContentAccessFactory.class );
     when( contentAccessFactory.getPluginSystemReader( anyString() ) ).thenReturn( mockedReadAccess );
     cache = new Cache( contentAccessFactory );
@@ -63,7 +63,7 @@ public class CacheTest {
 
   @Before
   public void setUp() {
-    this.cache.removeAll();
+    cache.removeAll();
     key = new DashboardCacheKey("mock", "", false, false, "", "" );
     value = new CdfRunJsDashboardWriteResult.Builder().build();
   }
@@ -74,32 +74,20 @@ public class CacheTest {
     key = null;
   }
 
-  @Test(expected = InitializationException.class)
-  public void testInitializationFailLoadConfiguration() throws InitializationException, IOException {
-    //try{
-      when( mockedReadAccess.getFileInputStream( any() ) )
-        .thenThrow( new IOException( "mocked IOException" ) );
-      new Cache( contentAccessFactory );
-      Assert.fail( "InitializationException not thrown" );/*
-    } catch ( InitializationException e ) {
-      Assert.assertEquals( "Failed to load the cache configuration file: ehcache.xml", e.getMessage() );
-    } catch ( Exception e ) {
-      Assert.fail( "InitializationException not thrown" );
-    }*/
+  @Test( expected = InitializationException.class )
+  public void testInitializationFailLoadConfiguration() throws Exception {
+    when( mockedReadAccess.getFileInputStream( any() ) )
+      .thenThrow( new IOException( "mocked IOException" ) );
+    new Cache( contentAccessFactory );
+    fail( "InitializationException not thrown" );
   }
 
-  @Test
-  public void testInitializationFailLoadCacheManager() {
-    try {
-      when( mockedReadAccess.getFileInputStream( anyString() ) )
-        .thenReturn( null );
-      new Cache( contentAccessFactory );
-      Assert.fail( "InitializationException not thrown" );
-    } catch ( InitializationException e ) {
-      Assert.assertEquals( "Failed to create the cache manager.", e.getMessage() );
-    } catch ( Exception e ) {
-      Assert.fail( "InitializationException not thrown" );
-    }
+  @Test( expected = InitializationException.class )
+  public void testInitializationFailLoadCacheManager() throws Exception {
+    when( mockedReadAccess.getFileInputStream( anyString() ) )
+      .thenReturn( null );
+    new Cache( contentAccessFactory );
+    fail( "InitializationException not thrown" );
   }
 
   @Test
@@ -125,7 +113,7 @@ public class CacheTest {
     cache.put( key, value );
     assertEquals( value, cache.get( key ) );
     cache.remove( key );
-    assertEquals( null, cache.get( key ) );
+    assertNull( cache.get( key ) );
   }
 
   @Test

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/cdf/CdfTemplatesTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/cdf/CdfTemplatesTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,8 +13,8 @@
 
 package pt.webdetails.cdf.dd.cdf;
 
-import junit.framework.Assert;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -38,22 +38,28 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class CdfTemplatesTest {
   private static final String RESOURCE_ENDPOINT = "resource_endpoint/";
+  private static final String[] TEMPLATES = { "Template1", "Template2", "Template3" };
+  private static final List<String> TEMPLATES_LIST = Arrays.asList( TEMPLATES );
 
-  private static String[] templates = { "Template1", "Template2", "Template3" };
-  private static List<String> templatesList = Arrays.asList( templates );
-
-  private static String savedTemplate = "";
+  private static String savedTemplate = StringUtils.EMPTY;
 
 
   @Before
   public void setUp() {
     CdeEnvironmentForTests cdeEnvironmentForTests = new CdeEnvironmentForTests();
 
-    List<IBasicFile> mockedFilesList = mockIBasicFiles( templatesList );
+    List<IBasicFile> mockedFilesList = mockIBasicFiles( TEMPLATES_LIST );
 
     // mocking IReadAccess
     IReadAccess mockedReadAccess = mock( IReadAccess.class );
@@ -90,7 +96,7 @@ public class CdfTemplatesTest {
     if ( obj instanceof JSONArray ) {
       verifyResult( (JSONArray) obj );
     } else {
-      Assert.fail( "Template loading should have built a JSONArray" );
+      fail( "Template loading should have built a JSONArray" );
     }
   }
 
@@ -101,33 +107,33 @@ public class CdfTemplatesTest {
 
     String fileStructure = "{components: [], rows: [], layout:{}, title:\"title\"}";
     cdfTemplates.save( fileName, fileStructure );
-    Assert.assertEquals( fileStructure, savedTemplate );
+    assertEquals( fileStructure, savedTemplate );
 
     fileStructure = "foo bar";
     cdfTemplates.save( fileName, fileStructure );
-    Assert.assertEquals( fileStructure, savedTemplate );
+    assertEquals( fileStructure, savedTemplate );
   }
 
   private void verifyResult( JSONArray arr ) throws JSONException {
-    Assert.assertTrue( "There should twice as much templates as were mocked (read from system and repository)",
-        arr.length() == ( templatesList.size() * 2 ) );
+    assertEquals( "There should twice as much templates as were mocked (read from system and repository)",
+      2 * TEMPLATES_LIST.size(), arr.length() );
     for ( int i = 0; i < arr.length(); i++ ) {
       Object obj = arr.get( i );
       if ( obj instanceof JSONObject ) {
         JSONObject structure = ( (JSONObject) obj ).getJSONObject( "structure" );
         String img =  ( (JSONObject) obj ).getString( "img" );
-        Assert.assertTrue( "img property should start with the resource endpoint",
+        assertTrue( "img property should start with the resource endpoint",
             img.startsWith( RESOURCE_ENDPOINT ) );
-        Assert.assertTrue( "Expecting fileName to be present in the templatesList (the array is ordered)",
-            structure.getString( "fileName" ).equals( templatesList.get( i % templatesList.size() ) ) );
+        assertEquals( "Expecting fileName to be present in the templatesList (the array is ordered)",
+          TEMPLATES_LIST.get( i % TEMPLATES_LIST.size() ), structure.getString( "fileName" ) );
       } else {
-        Assert.fail( "Only expecting JSONObject in the result array" );
+        fail( "Only expecting JSONObject in the result array" );
       }
     }
   }
 
   private static List<IBasicFile> mockIBasicFiles( List<String> files ) {
-    List<IBasicFile> iBasicFiles = new ArrayList<IBasicFile>();
+    List<IBasicFile> iBasicFiles = new ArrayList<>();
     for ( String file : files ) {
       IBasicFile iBasicFile = mock( IBasicFile.class );
       when( iBasicFile.getName() ).thenReturn( file );

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/reader/factory/ResourceLoaderFactoryTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/reader/factory/ResourceLoaderFactoryTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -16,15 +16,16 @@ package pt.webdetails.cdf.dd.reader.factory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import junit.framework.Assert;
+
+import static org.junit.Assert.assertEquals;
 
 public class ResourceLoaderFactoryTest {
 
   private static ResourceLoaderFactoryForTesting rlfft;
-  private final String SYS_PATH = "/system/pentaho-cdf-dd/etc/";
-  private final String SOL_PATH = "/public/cde/etc/";
-  private final String STATIC_PATH = "/path/etc/";
-  private final String EMPTY_PATH = "";
+  private static final String SYS_PATH = "/system/pentaho-cdf-dd/etc/";
+  private static final String SOL_PATH = "/public/cde/etc/";
+  private static final String STATIC_PATH = "/path/etc/";
+  private static final String EMPTY_PATH = "";
 
   @Before
   public void setUp() throws Exception {
@@ -39,33 +40,33 @@ public class ResourceLoaderFactoryTest {
   @Test
   public void testResourceFactorySystem() {
     IResourceLoader sys = rlfft.getResourceLoader( SYS_PATH );
-    Assert.assertEquals( sys.getClass(), SystemResourceLoader.class );
+    assertEquals( sys.getClass(), SystemResourceLoader.class );
   }
 
   @Test
   public void testResourceFactoryRepos() {
     IResourceLoader sol = rlfft.getResourceLoader( SOL_PATH );
-    Assert.assertEquals( sol.getClass(), SolutionResourceLoader.class );
+    assertEquals( sol.getClass(), SolutionResourceLoader.class );
   }
 
   @Test
   public void testResourceFactoryStaticSystem() {
     rlfft.setSystemStatic( true );
     IResourceLoader sys = rlfft.getResourceLoader( STATIC_PATH );
-    Assert.assertEquals( sys.getClass(), SystemResourceLoader.class );
+    assertEquals( sys.getClass(), SystemResourceLoader.class );
   }
 
   @Test
   public void testResourceFactoryStaticRepos() {
     rlfft.setRepositoryStatic( true );
     IResourceLoader sol = rlfft.getResourceLoader( STATIC_PATH );
-    Assert.assertEquals( sol.getClass(), SolutionResourceLoader.class );
+    assertEquals( sol.getClass(), SolutionResourceLoader.class );
   }
 
   @Test
   public void testResourceFactoryEmptyPath() {
     IResourceLoader sol = rlfft.getResourceLoader( EMPTY_PATH );
-    Assert.assertEquals( sol.getClass(), SolutionResourceLoader.class );
+    assertEquals( sol.getClass(), SolutionResourceLoader.class );
   }
 
 }

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/reader/factory/SystemResourceLoaderTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/reader/factory/SystemResourceLoaderTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,13 +13,15 @@
 
 package pt.webdetails.cdf.dd.reader.factory;
 
-import junit.framework.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import pt.webdetails.cpf.repository.api.FileAccess;
 import pt.webdetails.cpf.repository.api.IACAccess;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class SystemResourceLoaderTest {
 
@@ -49,11 +51,10 @@ public class SystemResourceLoaderTest {
     };
 
     Mockito.when( mockLoader.getAccessControl() ).thenReturn( mockAccess );
-    Assert.assertEquals( mockLoader.getAccessControl().hasAccess( "", FileAccess.READ ), true );
-    Assert.assertEquals( mockLoader.getAccessControl().hasAccess( "", FileAccess.WRITE ), true );
-    Assert.assertEquals( mockLoader.getAccessControl().hasAccess( "", FileAccess.EXECUTE ), true );
-    Assert.assertEquals( mockLoader.getAccessControl().hasAccess( "", FileAccess.DELETE ), true );
-
+    assertTrue( mockLoader.getAccessControl().hasAccess( "", FileAccess.READ ) );
+    assertTrue( mockLoader.getAccessControl().hasAccess( "", FileAccess.WRITE ) );
+    assertTrue( mockLoader.getAccessControl().hasAccess( "", FileAccess.EXECUTE ) );
+    assertTrue( mockLoader.getAccessControl().hasAccess( "", FileAccess.DELETE ) );
   }
 
   @Test
@@ -68,33 +69,10 @@ public class SystemResourceLoaderTest {
     };
 
     Mockito.when( mockLoader.getAccessControl() ).thenReturn( mockAccess );
-    Assert.assertEquals( mockLoader.getAccessControl().hasAccess( "", FileAccess.READ ), false );
-    Assert.assertEquals( mockLoader.getAccessControl().hasAccess( "", FileAccess.WRITE ), false );
-    Assert.assertEquals( mockLoader.getAccessControl().hasAccess( "", FileAccess.EXECUTE ), false );
-    Assert.assertEquals( mockLoader.getAccessControl().hasAccess( "", FileAccess.DELETE ), false );
+    assertFalse( mockLoader.getAccessControl().hasAccess( "", FileAccess.READ ) );
+    assertFalse( mockLoader.getAccessControl().hasAccess( "", FileAccess.WRITE ) );
+    assertFalse( mockLoader.getAccessControl().hasAccess( "", FileAccess.EXECUTE ) );
+    assertFalse( mockLoader.getAccessControl().hasAccess( "", FileAccess.DELETE ) );
   }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 }

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/settings/CdfDDSettingsForTesting.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/settings/CdfDDSettingsForTesting.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -21,7 +21,6 @@ import pt.webdetails.cdf.dd.CdeSettings;
 import pt.webdetails.cdf.dd.util.Utils;
 import pt.webdetails.cpf.repository.api.IRWAccess;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.List;
@@ -49,7 +48,7 @@ public class CdfDDSettingsForTesting extends CdeSettings.CdfDDSettings {
     InputStream input = null;
 
     try {
-      input = new FileInputStream( new File( SETTINGS_XML ) );
+      input = new FileInputStream( SETTINGS_XML );
       SAXReader reader = new SAXReader();
       settings = reader.read( input );
       return true;

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/settings/CdfDDSettingsTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/settings/CdfDDSettingsTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -14,12 +14,14 @@
 package pt.webdetails.cdf.dd.settings;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import pt.webdetails.cdf.dd.CdeSettings;
 import pt.webdetails.cpf.repository.api.IRWAccess;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class CdfDDSettingsTest {
 
@@ -39,11 +41,11 @@ public class CdfDDSettingsTest {
     String[] paths = cdfDDSettings.getFilePickerHiddenFoldersByType( CdeSettings.FolderType.STATIC );
 
     // we should have found 1 item
-    Assert.assertTrue( paths != null );
-    Assert.assertTrue( paths.length == 1 );
+    assertNotNull( paths );
+    assertEquals( 1, paths.length );
 
     // should have the value at SYSTEM_PATH_IN_SETTINGS_XML
-    Assert.assertTrue( paths[ 0 ].equals( SYSTEM_PATH_IN_SETTINGS_XML ) );
+    assertEquals( SYSTEM_PATH_IN_SETTINGS_XML, paths[ 0 ] );
   }
 
   @Test
@@ -52,11 +54,11 @@ public class CdfDDSettingsTest {
     String[] paths = cdfDDSettings.getFilePickerHiddenFoldersByType( CdeSettings.FolderType.REPO );
 
     // we should have found 1 item
-    Assert.assertTrue( paths != null );
-    Assert.assertTrue( paths.length == 1 );
+    assertNotNull( paths );
+    assertEquals( 1, paths.length );
 
     // should have the value at REPO_PATH_IN_SETTINGS_XML
-    Assert.assertTrue( paths[ 0 ].equals( REPO_PATH_IN_SETTINGS_XML ) );
+    assertEquals( REPO_PATH_IN_SETTINGS_XML, paths[ 0 ] );
   }
 
   @After

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/structure/DashboardWcdfDescriptorTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/structure/DashboardWcdfDescriptorTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2002 - 2017 Webdetails, a Hitachi Vantara company. All rights reserved.
+ * Copyright 2002 - 2021 Webdetails, a Hitachi Vantara company. All rights reserved.
  *
  * This software was developed by Webdetails and is provided under the terms
  * of the Mozilla Public License, Version 2.0, or any later version. You may not use
@@ -13,24 +13,23 @@
 
 package pt.webdetails.cdf.dd.structure;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 import org.junit.Test;
 
 import java.util.HashMap;
 
-public class DashboardWcdfDescriptorTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class DashboardWcdfDescriptorTest {
 
   private DashboardWcdfDescriptorForTest wcdf;
 
+  private static class DashboardWcdfDescriptorForTest extends DashboardWcdfDescriptor {
 
-  private class DashboardWcdfDescriptorForTest extends DashboardWcdfDescriptor {
-
-    private HashMap<String, Object> parameters;
+    private final HashMap<String, Object> parameters;
 
     public DashboardWcdfDescriptorForTest() {
       super();
-      this.parameters = new HashMap<String, Object>();
+      this.parameters = new HashMap<>();
     }
 
     public DashboardWcdfDescriptorForTest( String[] params ) {
@@ -45,7 +44,6 @@ public class DashboardWcdfDescriptorTest extends TestCase {
     private HashMap<String, Object> getParameters() {
       return this.parameters;
     }
-
   }
 
   @Test
@@ -53,7 +51,7 @@ public class DashboardWcdfDescriptorTest extends TestCase {
     wcdf = new DashboardWcdfDescriptorForTest();
     wcdf.update( wcdf.getParameters() );
 
-    Assert.assertTrue( "Should continue empty", wcdf.getWidgetParameters().length == 0 );
+    assertEquals( "Should continue empty", 0, wcdf.getWidgetParameters().length );
   }
 
   @Test
@@ -62,7 +60,7 @@ public class DashboardWcdfDescriptorTest extends TestCase {
     wcdf.addParameter( "widgetParameters", new String[] { "param1" } );
     wcdf.update( wcdf.getParameters() );
 
-    Assert.assertTrue( "Should have widget parameter 'param1'", wcdf.getWidgetParameters()[ 0 ].equals( "param1" ) );
+    assertEquals( "Should have widget parameter 'param1'", "param1", wcdf.getWidgetParameters()[ 0 ] );
   }
 
   @Test
@@ -70,6 +68,6 @@ public class DashboardWcdfDescriptorTest extends TestCase {
     wcdf = new DashboardWcdfDescriptorForTest( new String[] { "param1" } );
 
     wcdf.update( wcdf.getParameters() );
-    Assert.assertTrue( "'param1' should have been removed", wcdf.getWidgetParameters().length == 0 );
+    assertEquals( "'param1' should have been removed", 0, wcdf.getWidgetParameters().length );
   }
 }


### PR DESCRIPTION
…Java 11 and Java 8

Updated unit tests in order to be more compliant with the JUnit version were now using (there were JUnit 3.0 tests, deprecated imports, etc.).

@bcostahitachivantara @renato-s @andreramos89 