### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17

### DIFF
--- a/assemblies/cde-renderer/karaf/src/main/resources/etc/org.ops4j.pax.web.cfg
+++ b/assemblies/cde-renderer/karaf/src/main/resources/etc/org.ops4j.pax.web.cfg
@@ -1,3 +1,3 @@
 org.osgi.service.http.port=${http.port}
-javax.servlet.context.tempdir=${karaf.data}/pax-web-jsp
+jakarta.servlet.context.tempdir=${karaf.data}/pax-web-jsp
 org.ops4j.pax.web.config.file=${karaf.base}/etc/jetty.xml

--- a/assemblies/cde-renderer/solr/pom.xml
+++ b/assemblies/cde-renderer/solr/pom.xml
@@ -34,8 +34,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
+            <groupId>org.eclipse.jetty.ee10</groupId>
+            <artifactId>jetty-ee10-servlets</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/assemblies/cde-renderer/solr/pom.xml
+++ b/assemblies/cde-renderer/solr/pom.xml
@@ -38,8 +38,8 @@
             <artifactId>jetty-servlets</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/assemblies/cde-renderer/solr/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/assemblies/cde-renderer/solr/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,7 +4,7 @@
     <!-- Load system property -->
     <ext:property-placeholder />
 
-    <service interface="javax.servlet.Servlet">
+    <service interface="jakarta.servlet.Servlet">
         <service-properties>
             <entry key="alias" value="/solr"></entry>
             <entry key="init.Prefix" value="/"></entry>

--- a/assemblies/pdi/pom.xml
+++ b/assemblies/pdi/pom.xml
@@ -37,15 +37,15 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>javax.ws.rs</groupId>
-        <artifactId>javax.ws.rs-api</artifactId>
-        <version>${javax.ws.rs-api.version}</version>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>jakarta.ws.rs-api</artifactId>
+        <version>${jakarta.ws.rs-api.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>javax.servlet-api</artifactId>
-        <version>${servlet-api.version}</version>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>${jakarta.servlet.version}</version>
         <scope>provided</scope>
       </dependency>
       <!-- END provided dependencies via custom.properties -->

--- a/assemblies/platform/pentaho-cdf-dd/src/main/resources/ehcache.xml
+++ b/assemblies/platform/pentaho-cdf-dd/src/main/resources/ehcache.xml
@@ -1,168 +1,28 @@
-<ehcache name="cdeCache">
+<config
+		xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+		xmlns='http://www.ehcache.org/v3'
+		xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd">
 
+	<cache alias="pentaho-cde">
+		<key-type>java.lang.Object</key-type>
+		<value-type>java.lang.Object</value-type>
+		<expiry>
+			<ttl unit="seconds">120</ttl>
+		</expiry>
+		<resources>
+			<heap unit="entries">10000</heap>
+		</resources>
+	</cache>
 
-    <!--CDE Cache configuration. 
+	<cache alias="defaultCache">
+		<key-type>java.lang.Object</key-type>
+		<value-type>java.lang.Object</value-type>
+		<expiry>
+			<ttl unit="seconds">120</ttl>
+		</expiry>
+		<resources>
+			<heap unit="entries">10000</heap>
+		</resources>
+	</cache>
 
-        The following attributes are required:
-
-        maxElementsInMemory            - Sets the maximum number of objects that will be created in memory
-        eternal                        - Sets whether elements are eternal. If eternal,  timeouts are ignored and the
-                                         element is never expired.
-        overflowToDisk                 - Sets whether elements can overflow to disk when the in-memory cache
-                                         has reached the maxInMemory limit.
-
-        The following attributes are optional:
-
-				eternal 											 - Ignore timeouts, elements never expire.
-        timeToIdleSeconds              - Sets the time to idle for an element before it expires.
-                                         i.e. The maximum amount of time between accesses before an element expires
-                                         Is only used if the element is not eternal.
-                                         Optional attribute. A value of 0 means that an Element can idle for infinity.
-                                         The default value is 0.
-        timeToLiveSeconds              - Sets the time to live for an element before it expires.
-                                         i.e. The maximum time between creation time and when an element expires.
-                                         Is only used if the element is not eternal.
-                                         Optional attribute. A value of 0 means that and Element can live for infinity.
-                                         The default value is 0. (Overriden in .cda files)
-        diskPersistent                 - Whether the disk store persists between restarts of the Virtual Machine.
-                                         The default value is false.
-        diskExpiryThreadIntervalSeconds- The number of seconds between runs of the disk expiry thread. The default value
-                                         is 120 seconds.
-
-        memoryStoreEvictionPolicy      - LRU: Least Recently Used (Default); 
-                                         LFU: Less Frequently Used; 
-                                         FIFO: First In First Out.
-        maxElementsOnDisk              - Sets the maximum number of objects that will be kept on disk. Evictions from
-                                         disk will always use the LFU algorithm.
-        diskSpoolBufferSizeMB          - This is the size to allocate the DiskStore for a spool buffer. Writes are made
-                                         to this area and then asynchronously written to disk. The default size is 30MB.
-																					
-        -->	
-    <diskStore path="java.io.tmpdir/_pentaho-cde"/>
-    
-	<defaultCache
-        maxElementsInMemory="1000"
-        eternal="false"
-        overflowToDisk="false"
-        timeToIdleSeconds="0"
-        timeToLiveSeconds="0"
-        diskPersistent="false"
-        diskExpiryThreadIntervalSeconds="120"
-     />       
-        
-	<cache name="pentaho-cde"
-        maxElementsInMemory="50"
-				maxElementsOnDisk="500"
-        eternal="false"
-        overflowToDisk="true"
-        timeToIdleSeconds="0"
-        timeToLiveSeconds="0"
-        diskPersistent="false"
-        diskExpiryThreadIntervalSeconds="360"
-        memoryStoreEvictionPolicy="LFU"
-				diskSpoolBufferSizeMB="50"
-		/>
-
-    <!--
-    Cache configuration
-    ===================
-
-    The following attributes are required.
-
-    name:
-    Sets the name of the cache. This is used to identify the cache. It must be unique.
-
-    maxElementsInMemory:
-    Sets the maximum number of objects that will be created in memory.  0 == no limit.
-
-    maxElementsOnDisk:
-    Sets the maximum number of objects that will be maintained in the DiskStore
-    The default value is zero, meaning unlimited.
-
-    eternal:
-    Sets whether elements are eternal. If eternal,  timeouts are ignored and the
-    element is never expired.
-
-    overflowToDisk:
-    Sets whether elements can overflow to disk when the memory store
-    has reached the maxInMemory limit.
-
-    The following attributes and elements are optional.
-
-    timeToIdleSeconds:
-    Sets the time to idle for an element before it expires.
-    i.e. The maximum amount of time between accesses before an element expires
-    Is only used if the element is not eternal.
-    Optional attribute. A value of 0 means that an Element can idle for infinity.
-    The default value is 0.
-
-    timeToLiveSeconds:
-    Sets the time to live for an element before it expires.
-    i.e. The maximum time between creation time and when an element expires.
-    Is only used if the element is not eternal.
-    Optional attribute. A value of 0 means that and Element can live for infinity.
-    The default value is 0.
-
-    diskPersistent:
-    Whether the disk store persists between restarts of the Virtual Machine.
-    The default value is false.
-
-    diskExpiryThreadIntervalSeconds:
-    The number of seconds between runs of the disk expiry thread. The default value
-    is 120 seconds.
-
-    diskSpoolBufferSizeMB:
-    This is the size to allocate the DiskStore for a spool buffer. Writes are made
-    to this area and then asynchronously written to disk. The default size is 30MB.
-    Each spool buffer is used only by its cache. If you get OutOfMemory errors consider
-    lowering this value. To improve DiskStore performance consider increasing it. Trace level
-    logging in the DiskStore will show if put back ups are occurring.
-
-    clearOnFlush:
-    whether the MemoryStore should be cleared when flush() is called on the cache.
-    By default, this is true i.e. the MemoryStore is cleared.
-
-    statistics:
-    Whether to collect statistics. Ehcache runs twice as slow with statistics turned on.
-    By default they are off. To enable set statistics="true"
-
-    memoryStoreEvictionPolicy:
-    Policy would be enforced upon reaching the maxElementsInMemory limit. Default
-    policy is Least Recently Used (specified as LRU). Other policies available -
-    First In First Out (specified as FIFO) and Less Frequently Used
-    (specified as LFU)
-
-    copyOnRead:
-    Whether an Element is copied when being added to the cache.
-    By default this is false.
-
-    copyOnWrite:
-    Whether an Element is copied when being read from a cache.
-    By default this is false.
-
-    Cache elements can also contain sub elements which take the same format of a factory class
-    and properties. Defined sub-elements are:
-
-    * cacheEventListenerFactory - Enables registration of listeners for cache events, such as
-      put, remove, update, and expire.
-
-    * bootstrapCacheLoaderFactory - Specifies a BootstrapCacheLoader, which is called by a
-      cache on initialisation to prepopulate itself.
-
-    * cacheExtensionFactory - Specifies a CacheExtension, a generic mechanism to tie a class
-      which holds a reference to a cache to the cache lifecycle.
-
-    * cacheExceptionHandlerFactory - Specifies a CacheExceptionHandler, which is called when
-      cache exceptions occur.
-
-    * cacheLoaderFactory - Specifies a CacheLoader, which can be used both asynchronously and
-      synchronously to load objects into a cache. More than one cacheLoaderFactory element
-      can be added, in which case the loaders form a chain which are executed in order. If a
-      loader returns null, the next in chain is called.
-
-    * copyStrategy - Specifies a fully qualified class which implements
-      net.sf.ehcache.store.compound.CopyStrategy. This strategy will be used for copyOnRead
-      and copyOnWrite in place of the default which is serialization.
-		-->
-
-</ehcache>
+</config>

--- a/foundry-extensions/impl/pom.xml
+++ b/foundry-extensions/impl/pom.xml
@@ -58,12 +58,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-bundle</artifactId>
-      <version>${jersey-bundle.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>pentaho</groupId>
       <artifactId>pentaho-platform-api</artifactId>
       <version>${project.version}</version>

--- a/foundry-extensions/impl/pom.xml
+++ b/foundry-extensions/impl/pom.xml
@@ -39,8 +39,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>

--- a/foundry-extensions/impl/src/main/java/org/pentaho/ctools/cde/api/DashboardsApi.java
+++ b/foundry-extensions/impl/src/main/java/org/pentaho/ctools/cde/api/DashboardsApi.java
@@ -20,14 +20,14 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.pentaho.ctools.cde.impl.DashboardsImpl;
 
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path( "pentaho-cdf-dd/api/dashboards" )
 public class DashboardsApi {

--- a/osgi/impl/pom.xml
+++ b/osgi/impl/pom.xml
@@ -61,6 +61,7 @@
     <dependency>
       <groupId>org.ehcache</groupId>
       <artifactId>ehcache</artifactId>
+      <classifier>jakarta</classifier>
     </dependency>
     <dependency>
       <groupId>javax.cache</groupId>

--- a/osgi/impl/pom.xml
+++ b/osgi/impl/pom.xml
@@ -71,12 +71,12 @@
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>${jakarta.xml.bind-osgi.version}</version>
+      <version>${jakarta.xml.bind-api.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <version>${jakarta.xml.bind-osgi.version}</version>
+      <version>${jaxb-runtime.version}</version>
     </dependency>
 
     <dependency>

--- a/osgi/impl/pom.xml
+++ b/osgi/impl/pom.xml
@@ -50,12 +50,12 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
 
     <dependency>

--- a/osgi/impl/pom.xml
+++ b/osgi/impl/pom.xml
@@ -59,8 +59,13 @@
     </dependency>
 
     <dependency>
-      <groupId>net.sf.ehcache</groupId>
-      <artifactId>ehcache-core</artifactId>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+      <version>${cache-api.version}</version>
     </dependency>
 
     <dependency>

--- a/osgi/impl/pom.xml
+++ b/osgi/impl/pom.xml
@@ -67,6 +67,16 @@
       <artifactId>cache-api</artifactId>
       <version>${cache-api.version}</version>
     </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>${jakarta.xml.bind-osgi.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>${jakarta.xml.bind-osgi.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>

--- a/osgi/impl/src/main/java/org/pentaho/ctools/cde/api/RenderApi.java
+++ b/osgi/impl/src/main/java/org/pentaho/ctools/cde/api/RenderApi.java
@@ -13,15 +13,15 @@
 
 package org.pentaho.ctools.cde.api;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import pt.webdetails.cdf.dd.CdeConstants;

--- a/osgi/impl/src/main/java/org/pentaho/ctools/cde/api/ResourcesApi.java
+++ b/osgi/impl/src/main/java/org/pentaho/ctools/cde/api/ResourcesApi.java
@@ -18,10 +18,10 @@ import pt.webdetails.cdf.dd.util.Utils;
 import pt.webdetails.cpf.repository.api.IBasicFile;
 import pt.webdetails.cpf.utils.MimeTypes;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Response;
 
 import java.io.IOException;
 

--- a/osgi/impl/src/main/java/org/pentaho/ctools/cde/cache/impl/Cache.java
+++ b/osgi/impl/src/main/java/org/pentaho/ctools/cde/cache/impl/Cache.java
@@ -13,10 +13,8 @@
 
 package org.pentaho.ctools.cde.cache.impl;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import pt.webdetails.cdf.dd.DashboardCacheKey;
@@ -25,13 +23,9 @@ import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboa
 import pt.webdetails.cpf.exceptions.InitializationException;
 import pt.webdetails.cpf.repository.api.IReadAccess;
 
-import javax.cache.CacheException;
 import javax.cache.CacheManager;
 import javax.cache.Caching;
 import javax.cache.configuration.MutableConfiguration;
-import javax.cache.expiry.CreatedExpiryPolicy;
-import javax.cache.expiry.Duration;
-import javax.cache.spi.CachingProvider;
 /**
  * Allows caching {@code CdfRunJsDashboardWriteResult} objects referenced by {@code DashboardCacheKey}.
  * Both these types are serializable.
@@ -48,17 +42,10 @@ public final class Cache implements ICache {
   public Cache( IReadAccess readAccess ) throws InitializationException {
     CacheManager cacheManager;
     try {
-      CachingProvider cachingProvider = Caching.getCachingProvider();
-      URI configUri = getClass().getClassLoader().getResource( CACHE_CFG_FILE ).toURI();
-      cacheManager = cachingProvider.getCacheManager( configUri, getClass().getClassLoader() );
-      InputStream inputStream = readAccess.getFileInputStream( CACHE_CFG_FILE );
-      if (inputStream == null) {
-        throw new InitializationException( "Failed to create the cache manager." + CACHE_CFG_FILE, null );
-      }
-    } catch ( URISyntaxException e ) {
-        throw new RuntimeException( e );
-    } catch ( IOException e ) {
-      throw new InitializationException( "Failed to load configuration", e );
+      URI configUri = Path.of( readAccess.fetchFile( CACHE_CFG_FILE ).getFullPath() ).toUri();
+      cacheManager = Caching.getCachingProvider().getCacheManager( configUri, getClass().getClassLoader() );
+    } catch ( Exception e ) {
+      throw new InitializationException( "Failed to create the cache manager.", e );
     }
 
     // enableCacheProperShutdown

--- a/osgi/impl/src/main/java/org/pentaho/ctools/cde/cache/impl/Cache.java
+++ b/osgi/impl/src/main/java/org/pentaho/ctools/cde/cache/impl/Cache.java
@@ -14,6 +14,7 @@
 package org.pentaho.ctools.cde.cache.impl;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -50,10 +51,14 @@ public final class Cache implements ICache {
       CachingProvider cachingProvider = Caching.getCachingProvider();
       URI configUri = getClass().getClassLoader().getResource( CACHE_CFG_FILE ).toURI();
       cacheManager = cachingProvider.getCacheManager( configUri, getClass().getClassLoader() );
-    } catch ( CacheException e ) {
-      throw new InitializationException( "Failed to create the cache manager." + CACHE_CFG_FILE, e );
-    } catch (URISyntaxException e) {
+      InputStream inputStream = readAccess.getFileInputStream( CACHE_CFG_FILE );
+      if (inputStream == null) {
+        throw new InitializationException( "Failed to create the cache manager." + CACHE_CFG_FILE, null );
+      }
+    } catch ( URISyntaxException e ) {
         throw new RuntimeException( e );
+    } catch ( IOException e ) {
+      throw new InitializationException( "Failed to load configuration", e );
     }
 
     // enableCacheProperShutdown

--- a/osgi/impl/src/main/java/org/pentaho/ctools/cde/cache/impl/Cache.java
+++ b/osgi/impl/src/main/java/org/pentaho/ctools/cde/cache/impl/Cache.java
@@ -14,17 +14,23 @@
 package org.pentaho.ctools.cde.cache.impl;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
-import net.sf.ehcache.CacheException;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Ehcache;
-import net.sf.ehcache.Element;
 import pt.webdetails.cdf.dd.DashboardCacheKey;
 import pt.webdetails.cdf.dd.cache.api.ICache;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteResult;
 import pt.webdetails.cpf.exceptions.InitializationException;
 import pt.webdetails.cpf.repository.api.IReadAccess;
 
+import javax.cache.CacheException;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.expiry.CreatedExpiryPolicy;
+import javax.cache.expiry.Duration;
+import javax.cache.spi.CachingProvider;
 /**
  * Allows caching {@code CdfRunJsDashboardWriteResult} objects referenced by {@code DashboardCacheKey}.
  * Both these types are serializable.
@@ -35,39 +41,47 @@ import pt.webdetails.cpf.repository.api.IReadAccess;
 public final class Cache implements ICache {
   private static final String CACHE_CFG_FILE = "ehcache.xml";
   private static final String CACHE_NAME = "pentaho-cde";
-  private final Ehcache ehcache;
+  private static final String ENABLE_SHUTDOWN_HOOK_PROPERTY = "javax.cache.CacheManager.enableShutdownHook";
+  private final javax.cache.Cache ehcache;
 
   public Cache( IReadAccess readAccess ) throws InitializationException {
     CacheManager cacheManager;
     try {
-      cacheManager = CacheManager.create( readAccess.getFileInputStream( CACHE_CFG_FILE ) );
-    } catch ( IOException e ) {
-      throw new InitializationException( "Failed to load the cache configuration file: " + CACHE_CFG_FILE, e );
+      CachingProvider cachingProvider = Caching.getCachingProvider();
+      URI configUri = getClass().getClassLoader().getResource( CACHE_CFG_FILE ).toURI();
+      cacheManager = cachingProvider.getCacheManager( configUri, getClass().getClassLoader() );
     } catch ( CacheException e ) {
-      throw new InitializationException( "Failed to create the cache manager.", e );
+      throw new InitializationException( "Failed to create the cache manager." + CACHE_CFG_FILE, e );
+    } catch (URISyntaxException e) {
+        throw new RuntimeException( e );
     }
 
     // enableCacheProperShutdown
-    System.setProperty( CacheManager.ENABLE_SHUTDOWN_HOOK_PROPERTY, "true" );
+    System.setProperty( ENABLE_SHUTDOWN_HOOK_PROPERTY , "true" );
 
-    if ( !cacheManager.cacheExists( CACHE_NAME ) ) {
-      cacheManager.addCache( CACHE_NAME );
+    if ( cacheManager.getCache( CACHE_NAME ) == null ) {
+      MutableConfiguration<Object, Object> configuration =
+              new MutableConfiguration<>()
+                      .setStoreByValue( false );
+      cacheManager.createCache( CACHE_NAME ,configuration );
     }
 
     this.ehcache = cacheManager.getCache( CACHE_NAME );
   }
 
   public CdfRunJsDashboardWriteResult get( DashboardCacheKey key ) {
-    Element element = this.ehcache.get( key );
+    Object element = this.ehcache.get( key );
 
     if ( element != null ) {
-      return (CdfRunJsDashboardWriteResult) element.getValue();
+      return (CdfRunJsDashboardWriteResult) element;
     }
     return null;
   }
 
   public List<DashboardCacheKey> getKeys() {
-    return (List<DashboardCacheKey>) this.ehcache.getKeys();
+    List<DashboardCacheKey> keys = new ArrayList<>();
+    ehcache.iterator().forEachRemaining( entry -> keys.add( ( DashboardCacheKey ) ( ( javax.cache.Cache.Entry<Object,Object> ) entry ).getKey() ) );
+    return keys;
   }
 
   public void remove( DashboardCacheKey key ) {
@@ -79,7 +93,6 @@ public final class Cache implements ICache {
   }
 
   public void put( DashboardCacheKey key, CdfRunJsDashboardWriteResult value ) {
-    Element element = new Element( key, value );
-    this.ehcache.put( element );
+    this.ehcache.put( key, value );
   }
 }

--- a/osgi/impl/src/main/resources/ehcache.xml
+++ b/osgi/impl/src/main/resources/ehcache.xml
@@ -1,168 +1,28 @@
-<ehcache name="cdeCache">
+<config
+				xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+				xmlns='http://www.ehcache.org/v3'
+				xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd">
 
+	<cache alias="pentaho-cde">
+		<key-type>java.lang.Object</key-type>
+		<value-type>java.lang.Object</value-type>
+		<expiry>
+			<ttl unit="seconds">120</ttl>
+		</expiry>
+		<resources>
+			<heap unit="entries">10000</heap>
+		</resources>
+	</cache>
 
-    <!--CDE Cache configuration. 
+	<cache alias="defaultCache">
+		<key-type>java.lang.Object</key-type>
+		<value-type>java.lang.Object</value-type>
+		<expiry>
+			<ttl unit="seconds">120</ttl>
+		</expiry>
+		<resources>
+			<heap unit="entries">10000</heap>
+		</resources>
+	</cache>
 
-        The following attributes are required:
-
-        maxElementsInMemory            - Sets the maximum number of objects that will be created in memory
-        eternal                        - Sets whether elements are eternal. If eternal,  timeouts are ignored and the
-                                         element is never expired.
-        overflowToDisk                 - Sets whether elements can overflow to disk when the in-memory cache
-                                         has reached the maxInMemory limit.
-
-        The following attributes are optional:
-
-				eternal 											 - Ignore timeouts, elements never expire.
-        timeToIdleSeconds              - Sets the time to idle for an element before it expires.
-                                         i.e. The maximum amount of time between accesses before an element expires
-                                         Is only used if the element is not eternal.
-                                         Optional attribute. A value of 0 means that an Element can idle for infinity.
-                                         The default value is 0.
-        timeToLiveSeconds              - Sets the time to live for an element before it expires.
-                                         i.e. The maximum time between creation time and when an element expires.
-                                         Is only used if the element is not eternal.
-                                         Optional attribute. A value of 0 means that and Element can live for infinity.
-                                         The default value is 0. (Overriden in .cda files)
-        diskPersistent                 - Whether the disk store persists between restarts of the Virtual Machine.
-                                         The default value is false.
-        diskExpiryThreadIntervalSeconds- The number of seconds between runs of the disk expiry thread. The default value
-                                         is 120 seconds.
-
-        memoryStoreEvictionPolicy      - LRU: Least Recently Used (Default); 
-                                         LFU: Less Frequently Used; 
-                                         FIFO: First In First Out.
-        maxElementsOnDisk              - Sets the maximum number of objects that will be kept on disk. Evictions from
-                                         disk will always use the LFU algorithm.
-        diskSpoolBufferSizeMB          - This is the size to allocate the DiskStore for a spool buffer. Writes are made
-                                         to this area and then asynchronously written to disk. The default size is 30MB.
-																					
-        -->	
-    <diskStore path="java.io.tmpdir/_pentaho-cde"/>
-    
-	<defaultCache
-        maxElementsInMemory="1000"
-        eternal="false"
-        overflowToDisk="false"
-        timeToIdleSeconds="0"
-        timeToLiveSeconds="0"
-        diskPersistent="false"
-        diskExpiryThreadIntervalSeconds="120"
-     />       
-        
-	<cache name="pentaho-cde"
-        maxElementsInMemory="50"
-				maxElementsOnDisk="500"
-        eternal="false"
-        overflowToDisk="true"
-        timeToIdleSeconds="0"
-        timeToLiveSeconds="0"
-        diskPersistent="false"
-        diskExpiryThreadIntervalSeconds="360"
-        memoryStoreEvictionPolicy="LFU"
-				diskSpoolBufferSizeMB="50"
-		/>
-
-    <!--
-    Cache configuration
-    ===================
-
-    The following attributes are required.
-
-    name:
-    Sets the name of the cache. This is used to identify the cache. It must be unique.
-
-    maxElementsInMemory:
-    Sets the maximum number of objects that will be created in memory.  0 == no limit.
-
-    maxElementsOnDisk:
-    Sets the maximum number of objects that will be maintained in the DiskStore
-    The default value is zero, meaning unlimited.
-
-    eternal:
-    Sets whether elements are eternal. If eternal,  timeouts are ignored and the
-    element is never expired.
-
-    overflowToDisk:
-    Sets whether elements can overflow to disk when the memory store
-    has reached the maxInMemory limit.
-
-    The following attributes and elements are optional.
-
-    timeToIdleSeconds:
-    Sets the time to idle for an element before it expires.
-    i.e. The maximum amount of time between accesses before an element expires
-    Is only used if the element is not eternal.
-    Optional attribute. A value of 0 means that an Element can idle for infinity.
-    The default value is 0.
-
-    timeToLiveSeconds:
-    Sets the time to live for an element before it expires.
-    i.e. The maximum time between creation time and when an element expires.
-    Is only used if the element is not eternal.
-    Optional attribute. A value of 0 means that and Element can live for infinity.
-    The default value is 0.
-
-    diskPersistent:
-    Whether the disk store persists between restarts of the Virtual Machine.
-    The default value is false.
-
-    diskExpiryThreadIntervalSeconds:
-    The number of seconds between runs of the disk expiry thread. The default value
-    is 120 seconds.
-
-    diskSpoolBufferSizeMB:
-    This is the size to allocate the DiskStore for a spool buffer. Writes are made
-    to this area and then asynchronously written to disk. The default size is 30MB.
-    Each spool buffer is used only by its cache. If you get OutOfMemory errors consider
-    lowering this value. To improve DiskStore performance consider increasing it. Trace level
-    logging in the DiskStore will show if put back ups are occurring.
-
-    clearOnFlush:
-    whether the MemoryStore should be cleared when flush() is called on the cache.
-    By default, this is true i.e. the MemoryStore is cleared.
-
-    statistics:
-    Whether to collect statistics. Ehcache runs twice as slow with statistics turned on.
-    By default they are off. To enable set statistics="true"
-
-    memoryStoreEvictionPolicy:
-    Policy would be enforced upon reaching the maxElementsInMemory limit. Default
-    policy is Least Recently Used (specified as LRU). Other policies available -
-    First In First Out (specified as FIFO) and Less Frequently Used
-    (specified as LFU)
-
-    copyOnRead:
-    Whether an Element is copied when being added to the cache.
-    By default this is false.
-
-    copyOnWrite:
-    Whether an Element is copied when being read from a cache.
-    By default this is false.
-
-    Cache elements can also contain sub elements which take the same format of a factory class
-    and properties. Defined sub-elements are:
-
-    * cacheEventListenerFactory - Enables registration of listeners for cache events, such as
-      put, remove, update, and expire.
-
-    * bootstrapCacheLoaderFactory - Specifies a BootstrapCacheLoader, which is called by a
-      cache on initialisation to prepopulate itself.
-
-    * cacheExtensionFactory - Specifies a CacheExtension, a generic mechanism to tie a class
-      which holds a reference to a cache to the cache lifecycle.
-
-    * cacheExceptionHandlerFactory - Specifies a CacheExceptionHandler, which is called when
-      cache exceptions occur.
-
-    * cacheLoaderFactory - Specifies a CacheLoader, which can be used both asynchronously and
-      synchronously to load objects into a cache. More than one cacheLoaderFactory element
-      can be added, in which case the loaders form a chain which are executed in order. If a
-      loader returns null, the next in chain is called.
-
-    * copyStrategy - Specifies a fully qualified class which implements
-      net.sf.ehcache.store.compound.CopyStrategy. This strategy will be used for copyOnRead
-      and copyOnWrite in place of the default which is serialization.
-		-->
-
-</ehcache>
+</config>

--- a/osgi/impl/src/test/java/org/pentaho/ctools/cde/api/RenderApiTest.java
+++ b/osgi/impl/src/test/java/org/pentaho/ctools/cde/api/RenderApiTest.java
@@ -13,7 +13,7 @@
 
 package org.pentaho.ctools.cde.api;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Before;

--- a/osgi/impl/src/test/java/org/pentaho/ctools/cde/api/ResourcesApiTest.java
+++ b/osgi/impl/src/test/java/org/pentaho/ctools/cde/api/ResourcesApiTest.java
@@ -16,8 +16,8 @@ import org.junit.Before;
 import org.junit.Test;
 import pt.webdetails.cpf.repository.api.IBasicFile;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;

--- a/pentaho/impl/pom.xml
+++ b/pentaho/impl/pom.xml
@@ -108,6 +108,7 @@
     <dependency>
       <groupId>org.ehcache</groupId>
       <artifactId>ehcache</artifactId>
+      <classifier>jakarta</classifier>
     </dependency>
     <dependency>
       <groupId>javax.cache</groupId>

--- a/pentaho/impl/pom.xml
+++ b/pentaho/impl/pom.xml
@@ -56,6 +56,16 @@
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>${jakarta.xml.bind-osgi.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>${jakarta.xml.bind-osgi.version}</version>
+    </dependency>
+    <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
@@ -137,7 +147,12 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-mock</artifactId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pentaho/impl/pom.xml
+++ b/pentaho/impl/pom.xml
@@ -52,12 +52,12 @@
       <artifactId>json</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>

--- a/pentaho/impl/pom.xml
+++ b/pentaho/impl/pom.xml
@@ -96,8 +96,13 @@
     </dependency>
 
     <dependency>
-      <groupId>net.sf.ehcache</groupId>
-      <artifactId>ehcache-core</artifactId>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+      <version>${cache-api.version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>

--- a/pentaho/impl/pom.xml
+++ b/pentaho/impl/pom.xml
@@ -58,12 +58,12 @@
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>${jakarta.xml.bind-osgi.version}</version>
+      <version>${jakarta.xml.bind-api.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <version>${jakarta.xml.bind-osgi.version}</version>
+      <version>${jaxb-runtime.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>

--- a/pentaho/impl/pom.xml
+++ b/pentaho/impl/pom.xml
@@ -60,8 +60,9 @@
       <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-multipart</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-multipart</artifactId>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/DashboardDesignerContentGenerator.java
+++ b/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/DashboardDesignerContentGenerator.java
@@ -22,9 +22,9 @@ import pt.webdetails.cpf.audit.CpfAuditHelper;
 import pt.webdetails.cpf.utils.MimeTypes;
 import pt.webdetails.cpf.utils.PluginIOUtils;
 
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
 import java.io.IOException;
 import java.util.UUID;
 

--- a/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/DatasourcesApi.java
+++ b/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/DatasourcesApi.java
@@ -16,11 +16,11 @@ package pt.webdetails.cdf.dd.api;
 import static pt.webdetails.cpf.utils.MimeTypes.JAVASCRIPT;
 
 import java.util.List;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.DefaultValue;
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONException;
 import pt.webdetails.cdf.dd.datasources.CdaDataSourceReader;

--- a/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/EditorApi.java
+++ b/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/EditorApi.java
@@ -13,27 +13,27 @@
 
 package pt.webdetails.cdf.dd.api;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.MediaType.APPLICATION_XML;
-import static javax.ws.rs.core.MediaType.TEXT_HTML;
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
+import static jakarta.ws.rs.core.MediaType.TEXT_HTML;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 import static pt.webdetails.cpf.utils.MimeTypes.JAVASCRIPT;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;

--- a/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/PluginsApi.java
+++ b/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/PluginsApi.java
@@ -15,9 +15,9 @@ package pt.webdetails.cdf.dd.api;
 
 import static pt.webdetails.cpf.utils.MimeTypes.JAVASCRIPT;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 import pt.webdetails.cdf.dd.CdePlugins;
 
 @Path( "/pentaho-cdf-dd/api/plugins" )

--- a/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/RenderApi.java
+++ b/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/RenderApi.java
@@ -48,20 +48,20 @@ import pt.webdetails.cpf.localization.MessageBundlesHelper;
 import pt.webdetails.cpf.repository.api.IReadAccess;
 import pt.webdetails.cpf.utils.CharsetHelper;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
 import java.util.Map;
 import java.util.UUID;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.MediaType.TEXT_HTML;
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.TEXT_HTML;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 import static pt.webdetails.cpf.utils.MimeTypes.JAVASCRIPT;
 
 @Path( "pentaho-cdf-dd/api/renderer" )

--- a/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/ResourcesApi.java
+++ b/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/ResourcesApi.java
@@ -13,7 +13,7 @@
 
 package pt.webdetails.cdf.dd.api;
 
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 import static pt.webdetails.cpf.utils.MimeTypes.CSS;
 import static pt.webdetails.cpf.utils.MimeTypes.JAVASCRIPT;
 
@@ -22,20 +22,20 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.StreamingOutput;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.StreamingOutput;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;

--- a/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/SyncronizerApi.java
+++ b/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/SyncronizerApi.java
@@ -17,7 +17,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
 
-import com.sun.jersey.multipart.FormDataParam;
+import org.glassfish.jersey.media.multipart.FormDataParam;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;

--- a/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/SyncronizerApi.java
+++ b/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/SyncronizerApi.java
@@ -13,9 +13,9 @@
 
 package pt.webdetails.cdf.dd.api;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
-import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static jakarta.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
 
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import java.io.IOException;
@@ -24,18 +24,18 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;

--- a/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/VersionApi.java
+++ b/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/api/VersionApi.java
@@ -13,12 +13,12 @@
 
 package pt.webdetails.cdf.dd.api;
 
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
 
 import org.json.JSONException;
 import pt.webdetails.cdf.dd.CdeSettings;

--- a/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/cache/impl/Cache.java
+++ b/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/cache/impl/Cache.java
@@ -14,6 +14,7 @@
 package pt.webdetails.cdf.dd.cache.impl;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -49,10 +50,15 @@ public final class Cache implements ICache {
       CachingProvider cachingProvider = Caching.getCachingProvider();
       URI configUri = getClass().getClassLoader().getResource( CACHE_CFG_FILE ).toURI();
       cacheManager = cachingProvider.getCacheManager( configUri, getClass().getClassLoader() );
-    } catch ( CacheException e ) {
-      throw new InitializationException( "Failed to create the cache manager.", e );
+      InputStream inputStream = contentAccessFactory.getPluginSystemReader( null )
+        .getFileInputStream( CACHE_CFG_FILE );
+      if ( inputStream == null ) {
+        throw new InitializationException( "Failed to create the cache manager." + CACHE_CFG_FILE, null );
+      }
     } catch ( URISyntaxException e ) {
-        throw new RuntimeException( "Failed to load the cache configuration file: " + CACHE_CFG_FILE, e );
+        throw new RuntimeException( e );
+    } catch ( IOException e ) {
+      throw new InitializationException( "Failed to load the cache configuration file: " + CACHE_CFG_FILE, e );
     }
 
     // enableCacheProperShutdown

--- a/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/cache/impl/Cache.java
+++ b/pentaho/impl/src/main/java/pt/webdetails/cdf/dd/cache/impl/Cache.java
@@ -14,17 +14,21 @@
 package pt.webdetails.cdf.dd.cache.impl;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
-import net.sf.ehcache.CacheException;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Ehcache;
-import net.sf.ehcache.Element;
 import pt.webdetails.cdf.dd.DashboardCacheKey;
 import pt.webdetails.cdf.dd.cache.api.ICache;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteResult;
 import pt.webdetails.cpf.exceptions.InitializationException;
 import pt.webdetails.cpf.repository.api.IContentAccessFactory;
 
+import javax.cache.CacheException;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.spi.CachingProvider;
 /**
  * Allows caching {@code CdfRunJsDashboardWriteResult} objects referenced by {@code DashboardCacheKey}.
  * Both these types are serializable.
@@ -35,41 +39,46 @@ import pt.webdetails.cpf.repository.api.IContentAccessFactory;
 public final class Cache implements ICache {
   private static final String CACHE_CFG_FILE = "ehcache.xml";
   private static final String CACHE_NAME = "pentaho-cde";
-  private Ehcache ehcache;
+  private static final String ENABLE_SHUTDOWN_HOOK_PROPERTY = "javax.cache.CacheManager.enableShutdownHook";
+  private javax.cache.Cache ehcache;
 
   public Cache( IContentAccessFactory contentAccessFactory ) throws InitializationException {
 
     CacheManager cacheManager;
     try {
-      cacheManager = CacheManager.create( contentAccessFactory.getPluginSystemReader( null )
-        .getFileInputStream( CACHE_CFG_FILE ) );
-    } catch ( IOException e ) {
-      throw new InitializationException( "Failed to load the cache configuration file: " + CACHE_CFG_FILE, e );
+      CachingProvider cachingProvider = Caching.getCachingProvider();
+      URI configUri = getClass().getClassLoader().getResource( CACHE_CFG_FILE ).toURI();
+      cacheManager = cachingProvider.getCacheManager( configUri, getClass().getClassLoader() );
     } catch ( CacheException e ) {
       throw new InitializationException( "Failed to create the cache manager.", e );
+    } catch ( URISyntaxException e ) {
+        throw new RuntimeException( "Failed to load the cache configuration file: " + CACHE_CFG_FILE, e );
     }
 
     // enableCacheProperShutdown
-    System.setProperty( CacheManager.ENABLE_SHUTDOWN_HOOK_PROPERTY, "true" );
+    System.setProperty( ENABLE_SHUTDOWN_HOOK_PROPERTY, "true" );
 
-    if ( !cacheManager.cacheExists( CACHE_NAME ) ) {
-      cacheManager.addCache( CACHE_NAME );
+    if ( cacheManager.getCache( CACHE_NAME ) == null ) {
+        MutableConfiguration<Object,Object> config = new MutableConfiguration<>().setStoreByValue( false );
+      cacheManager.createCache( CACHE_NAME, config );
     }
 
     this.ehcache = cacheManager.getCache( CACHE_NAME );
   }
 
   public CdfRunJsDashboardWriteResult get( DashboardCacheKey key ) {
-    Element element = this.ehcache.get( key );
+    Object element = this.ehcache.get( key );
 
     if ( element != null ) {
-      return (CdfRunJsDashboardWriteResult) element.getValue();
+      return (CdfRunJsDashboardWriteResult) element;
     }
     return null;
   }
 
   public List<DashboardCacheKey> getKeys() {
-    return (List<DashboardCacheKey>) this.ehcache.getKeys();
+    final List<DashboardCacheKey> keys = new ArrayList<>();
+    ehcache.iterator().forEachRemaining( entry -> keys.add( ( ( javax.cache.Cache.Entry<DashboardCacheKey, CdfRunJsDashboardWriteResult> ) entry ).getKey() ) );
+    return keys;
   }
 
   public void remove( DashboardCacheKey key ) {
@@ -81,7 +90,6 @@ public final class Cache implements ICache {
   }
 
   public void put( DashboardCacheKey key, CdfRunJsDashboardWriteResult value ) {
-    Element element = new Element( key, value );
-    this.ehcache.put( element );
+    this.ehcache.put( key, value );
   }
 }

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/DashboardDesignerContentGeneratorTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/DashboardDesignerContentGeneratorTest.java
@@ -1,140 +1,140 @@
-///*! ******************************************************************************
-// *
-// * Pentaho
-// *
-// * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
-// *
-// * Use of this software is governed by the Business Source License included
-// * in the LICENSE.TXT file.
-// *
-// * Change Date: 2029-07-20
-// ******************************************************************************/
-//
-//package pt.webdetails.cdf.dd;
-//
-//import org.junit.After;
-//import org.junit.Before;
-//import org.junit.Test;
-//import org.mockito.MockedStatic;
-//import org.pentaho.platform.api.engine.IParameterProvider;
-//import org.pentaho.platform.api.engine.IPluginResourceLoader;
-//import org.pentaho.platform.engine.core.solution.SimpleParameterProvider;
-//import org.pentaho.platform.web.http.request.HttpRequestParameterProvider;
-//import org.springframework.mock.web.MockHttpServletResponse;
-//import pt.webdetails.cdf.dd.api.ResourcesApi;
-//import pt.webdetails.cdf.dd.api.XSSHelper;
-//import pt.webdetails.cdf.dd.util.CdeEnvironment;
-//import pt.webdetails.cdf.dd.util.Utils;
-//import pt.webdetails.cpf.repository.api.IBasicFile;
-//import pt.webdetails.cpf.repository.api.IRWAccess;
-//import pt.webdetails.cpf.repository.api.IUserContentAccess;
-//
-//import javax.servlet.http.HttpServletRequest;
-//import java.io.ByteArrayInputStream;
-//import java.util.ArrayList;
-//import java.util.HashMap;
-//import java.util.List;
-//import java.util.Map;
-//
-//import static org.junit.Assert.assertEquals;
-//import static org.mockito.Mockito.doReturn;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.mockStatic;
-//import static org.mockito.Mockito.spy;
-//import static org.mockito.Mockito.when;
-//
-//
-//public class DashboardDesignerContentGeneratorTest {
-//
-//  private static final String PLUGIN_NAME = "pentaho-cdf-dd";
-//  private static final String COMMAND = "test/path/file.json";
-//  private DashboardDesignerContentGenerator contentGenerator;
-//  private MockHttpServletResponse servletResponse;
-//  private IPluginResourceLoader iPluginResourceLoader;
-//  private XSSHelper xssHelper;
-//
-//  private MockedStatic<XSSHelper> xssHelperMockedStatic;
-//  private MockedStatic<Utils> utilsMockedStatic;
-//  private MockedStatic<Long> longMockedStatic;
-//  private MockedStatic<CdeEnvironment> cdeEnvironmentMockedStatic;
-//
-//  @Before
-//  public void setUp() {
-//    xssHelperMockedStatic = mockStatic( XSSHelper.class );
-//    utilsMockedStatic = mockStatic( Utils.class );
-//    longMockedStatic = mockStatic( Long.class );
-//    cdeEnvironmentMockedStatic = mockStatic( CdeEnvironment.class );
-//
-//    xssHelper = mock( XSSHelper.class );
-//    iPluginResourceLoader = mock( IPluginResourceLoader.class );
-//    contentGenerator = spy( new DashboardDesignerContentGenerator() );
-//
-//    servletResponse = new MockHttpServletResponse();
-//
-//  }
-//
-//  @After
-//  public void afterEach() {
-//    xssHelperMockedStatic.close();
-//    utilsMockedStatic.close();
-//    longMockedStatic.close();
-//    cdeEnvironmentMockedStatic.close();
-//  }
-//
-//  @Test
-//  public void createJsonResourceContent() throws Exception {
-//    contentGenerator.setParameterProviders( configureParameterProviders() );
-//    doReturn( PLUGIN_NAME ).when( contentGenerator ).getPluginName();
-//    contentGenerator.setResource( true );
-//
-//    String expectedJsonContents = "jsonBufferedValues";
-//    setUpJsonResourceStatements( expectedJsonContents );
-//    contentGenerator.createContent();
-//
-//    // The expectedJsonContents string is an input into the Response object, then it gets translated over to the
-//    // servletResponse's object. this byteStream check verifies the output the servletResponse writes to.
-//    assertEquals( expectedJsonContents, servletResponse.getContentAsString() );
-//
-//    assertEquals( "inline; filename=\"null\"", servletResponse.getHeader( "content-disposition" ) );
-//    assertEquals( "application/unknown", servletResponse.getHeader( "Content-Type" ) );
-//    assertEquals( 2, servletResponse.getHeaderNames().size() );
-//  }
-//
-//  private Map<String, IParameterProvider> configureParameterProviders() {
-//    Map<String, IParameterProvider> parameterProviders = new HashMap<>();
-//    SimpleParameterProvider pathProvider = new SimpleParameterProvider();
-//    pathProvider.setParameter( "cmd", COMMAND );
-//    pathProvider.setParameter( "httpresponse", servletResponse );
-//    parameterProviders.put( "request", new HttpRequestParameterProvider( mock( HttpServletRequest.class ) ) );
-//    parameterProviders.put( "path", pathProvider );
-//    return parameterProviders;
-//  }
-//
-//  private void setUpJsonResourceStatements( String expectedJsonContents ) throws Exception {
-//    IUserContentAccess userContentAccess = mock( IUserContentAccess.class );
-//    IRWAccess readWriteAccess = mock( IRWAccess.class );
-//    IBasicFile file = mock( IBasicFile.class );
-//
-//    when( XSSHelper.getInstance() ).thenReturn( xssHelper );
-//    when( CdeEnvironment.getUserContentAccess() ).thenReturn( userContentAccess );
-//    when( Utils.getAppropriateWriteAccess( COMMAND ) ).thenReturn( readWriteAccess );
-//    when( Utils.getFileViaAppropriateReadAccess( COMMAND ) ).thenReturn( file );
-//    when( Utils.getURLDecoded( COMMAND ) ).thenReturn( COMMAND );
-//
-//    when( userContentAccess.getLastModified( COMMAND )).thenReturn( Long.valueOf( "0" ) );
-//    doReturn( ".json" ).when( file ).getExtension();
-//    doReturn( COMMAND ).when( xssHelper ).escape( COMMAND );
-//
-//    //Added to set json as an allowed extension for test after removing PentahoSystem mock
-//    List<String> allowedExtensions = new ArrayList<>();
-//    allowedExtensions.add( "json" );
-//    ResourcesApi.setAllowedExtensions( allowedExtensions );
-//    doReturn( "json" ).when( iPluginResourceLoader ).getPluginSetting( ResourcesApi.class,
-//      "settings/resources/downloadable-formats" );
-//    doReturn( null ).when( iPluginResourceLoader ).getPluginSetting( ResourcesApi.class,
-//      "max-age" );
-//
-//    doReturn( new ByteArrayInputStream( expectedJsonContents.getBytes() ) ).when( file ).getContents();
-//  }
-//
-//}
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package pt.webdetails.cdf.dd;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.pentaho.platform.api.engine.IParameterProvider;
+import org.pentaho.platform.api.engine.IPluginResourceLoader;
+import org.pentaho.platform.engine.core.solution.SimpleParameterProvider;
+import org.pentaho.platform.web.http.request.HttpRequestParameterProvider;
+import pt.webdetails.cdf.dd.api.ResourcesApi;
+import org.springframework.mock.web.MockHttpServletResponse;
+import pt.webdetails.cdf.dd.api.XSSHelper;
+import pt.webdetails.cdf.dd.util.CdeEnvironment;
+import pt.webdetails.cdf.dd.util.Utils;
+import pt.webdetails.cpf.repository.api.IBasicFile;
+import pt.webdetails.cpf.repository.api.IRWAccess;
+import pt.webdetails.cpf.repository.api.IUserContentAccess;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+
+public class DashboardDesignerContentGeneratorTest {
+
+  private static final String PLUGIN_NAME = "pentaho-cdf-dd";
+  private static final String COMMAND = "test/path/file.json";
+  private DashboardDesignerContentGenerator contentGenerator;
+  private MockHttpServletResponse servletResponse;
+  private IPluginResourceLoader iPluginResourceLoader;
+  private XSSHelper xssHelper;
+
+  private MockedStatic<XSSHelper> xssHelperMockedStatic;
+  private MockedStatic<Utils> utilsMockedStatic;
+  private MockedStatic<Long> longMockedStatic;
+  private MockedStatic<CdeEnvironment> cdeEnvironmentMockedStatic;
+
+  @Before
+  public void setUp() {
+    xssHelperMockedStatic = mockStatic( XSSHelper.class );
+    utilsMockedStatic = mockStatic( Utils.class );
+    longMockedStatic = mockStatic( Long.class );
+    cdeEnvironmentMockedStatic = mockStatic( CdeEnvironment.class );
+
+    xssHelper = mock( XSSHelper.class );
+    iPluginResourceLoader = mock( IPluginResourceLoader.class );
+    contentGenerator = spy( new DashboardDesignerContentGenerator() );
+
+    servletResponse = new MockHttpServletResponse();
+
+  }
+
+  @After
+  public void afterEach() {
+    xssHelperMockedStatic.close();
+    utilsMockedStatic.close();
+    longMockedStatic.close();
+    cdeEnvironmentMockedStatic.close();
+  }
+
+  @Test
+  public void createJsonResourceContent() throws Exception {
+    contentGenerator.setParameterProviders( configureParameterProviders() );
+    doReturn( PLUGIN_NAME ).when( contentGenerator ).getPluginName();
+    contentGenerator.setResource( true );
+
+    String expectedJsonContents = "jsonBufferedValues";
+    setUpJsonResourceStatements( expectedJsonContents );
+    contentGenerator.createContent();
+
+    // The expectedJsonContents string is an input into the Response object, then it gets translated over to the
+    // servletResponse's object. this byteStream check verifies the output the servletResponse writes to.
+    assertEquals( expectedJsonContents, servletResponse.getContentAsString() );
+
+    assertEquals( "inline; filename=\"null\"", servletResponse.getHeader( "content-disposition" ) );
+    assertEquals( "application/unknown", servletResponse.getHeader( "Content-Type" ) );
+    assertEquals( 2, servletResponse.getHeaderNames().size() );
+  }
+
+  private Map<String, IParameterProvider> configureParameterProviders() {
+    Map<String, IParameterProvider> parameterProviders = new HashMap<>();
+    SimpleParameterProvider pathProvider = new SimpleParameterProvider();
+    pathProvider.setParameter( "cmd", COMMAND );
+    pathProvider.setParameter( "httpresponse", servletResponse );
+    parameterProviders.put( "request", new HttpRequestParameterProvider( mock( HttpServletRequest.class ) ) );
+    parameterProviders.put( "path", pathProvider );
+    return parameterProviders;
+  }
+
+  private void setUpJsonResourceStatements( String expectedJsonContents ) throws Exception {
+    IUserContentAccess userContentAccess = mock( IUserContentAccess.class );
+    IRWAccess readWriteAccess = mock( IRWAccess.class );
+    IBasicFile file = mock( IBasicFile.class );
+
+    when( XSSHelper.getInstance() ).thenReturn( xssHelper );
+    when( CdeEnvironment.getUserContentAccess() ).thenReturn( userContentAccess );
+    when( Utils.getAppropriateWriteAccess( COMMAND ) ).thenReturn( readWriteAccess );
+    when( Utils.getFileViaAppropriateReadAccess( COMMAND ) ).thenReturn( file );
+    when( Utils.getURLDecoded( COMMAND ) ).thenReturn( COMMAND );
+
+    when( userContentAccess.getLastModified( COMMAND )).thenReturn( Long.valueOf( "0" ) );
+    doReturn( ".json" ).when( file ).getExtension();
+    doReturn( COMMAND ).when( xssHelper ).escape( COMMAND );
+
+    //Added to set json as an allowed extension for test after removing PentahoSystem mock
+    List<String> allowedExtensions = new ArrayList<>();
+    allowedExtensions.add( "json" );
+    ResourcesApi.setAllowedExtensions( allowedExtensions );
+    doReturn( "json" ).when( iPluginResourceLoader ).getPluginSetting( ResourcesApi.class,
+      "settings/resources/downloadable-formats" );
+    doReturn( null ).when( iPluginResourceLoader ).getPluginSetting( ResourcesApi.class,
+      "max-age" );
+
+    doReturn( new ByteArrayInputStream( expectedJsonContents.getBytes() ) ).when( file ).getContents();
+  }
+
+}

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/DashboardDesignerContentGeneratorTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/DashboardDesignerContentGeneratorTest.java
@@ -1,140 +1,140 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2029-07-20
- ******************************************************************************/
-
-package pt.webdetails.cdf.dd;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.MockedStatic;
-import org.pentaho.platform.api.engine.IParameterProvider;
-import org.pentaho.platform.api.engine.IPluginResourceLoader;
-import org.pentaho.platform.engine.core.solution.SimpleParameterProvider;
-import org.pentaho.platform.web.http.request.HttpRequestParameterProvider;
-import org.springframework.mock.web.MockHttpServletResponse;
-import pt.webdetails.cdf.dd.api.ResourcesApi;
-import pt.webdetails.cdf.dd.api.XSSHelper;
-import pt.webdetails.cdf.dd.util.CdeEnvironment;
-import pt.webdetails.cdf.dd.util.Utils;
-import pt.webdetails.cpf.repository.api.IBasicFile;
-import pt.webdetails.cpf.repository.api.IRWAccess;
-import pt.webdetails.cpf.repository.api.IUserContentAccess;
-
-import javax.servlet.http.HttpServletRequest;
-import java.io.ByteArrayInputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-
-
-public class DashboardDesignerContentGeneratorTest {
-
-  private static final String PLUGIN_NAME = "pentaho-cdf-dd";
-  private static final String COMMAND = "test/path/file.json";
-  private DashboardDesignerContentGenerator contentGenerator;
-  private MockHttpServletResponse servletResponse;
-  private IPluginResourceLoader iPluginResourceLoader;
-  private XSSHelper xssHelper;
-
-  private MockedStatic<XSSHelper> xssHelperMockedStatic;
-  private MockedStatic<Utils> utilsMockedStatic;
-  private MockedStatic<Long> longMockedStatic;
-  private MockedStatic<CdeEnvironment> cdeEnvironmentMockedStatic;
-
-  @Before
-  public void setUp() {
-    xssHelperMockedStatic = mockStatic( XSSHelper.class );
-    utilsMockedStatic = mockStatic( Utils.class );
-    longMockedStatic = mockStatic( Long.class );
-    cdeEnvironmentMockedStatic = mockStatic( CdeEnvironment.class );
-
-    xssHelper = mock( XSSHelper.class );
-    iPluginResourceLoader = mock( IPluginResourceLoader.class );
-    contentGenerator = spy( new DashboardDesignerContentGenerator() );
-
-    servletResponse = new MockHttpServletResponse();
-
-  }
-
-  @After
-  public void afterEach() {
-    xssHelperMockedStatic.close();
-    utilsMockedStatic.close();
-    longMockedStatic.close();
-    cdeEnvironmentMockedStatic.close();
-  }
-
-  @Test
-  public void createJsonResourceContent() throws Exception {
-    contentGenerator.setParameterProviders( configureParameterProviders() );
-    doReturn( PLUGIN_NAME ).when( contentGenerator ).getPluginName();
-    contentGenerator.setResource( true );
-
-    String expectedJsonContents = "jsonBufferedValues";
-    setUpJsonResourceStatements( expectedJsonContents );
-    contentGenerator.createContent();
-
-    // The expectedJsonContents string is an input into the Response object, then it gets translated over to the
-    // servletResponse's object. this byteStream check verifies the output the servletResponse writes to.
-    assertEquals( expectedJsonContents, servletResponse.getContentAsString() );
-
-    assertEquals( "inline; filename=\"null\"", servletResponse.getHeader( "content-disposition" ) );
-    assertEquals( "application/unknown", servletResponse.getHeader( "Content-Type" ) );
-    assertEquals( 2, servletResponse.getHeaderNames().size() );
-  }
-
-  private Map<String, IParameterProvider> configureParameterProviders() {
-    Map<String, IParameterProvider> parameterProviders = new HashMap<>();
-    SimpleParameterProvider pathProvider = new SimpleParameterProvider();
-    pathProvider.setParameter( "cmd", COMMAND );
-    pathProvider.setParameter( "httpresponse", servletResponse );
-    parameterProviders.put( "request", new HttpRequestParameterProvider( mock( HttpServletRequest.class ) ) );
-    parameterProviders.put( "path", pathProvider );
-    return parameterProviders;
-  }
-
-  private void setUpJsonResourceStatements( String expectedJsonContents ) throws Exception {
-    IUserContentAccess userContentAccess = mock( IUserContentAccess.class );
-    IRWAccess readWriteAccess = mock( IRWAccess.class );
-    IBasicFile file = mock( IBasicFile.class );
-
-    when( XSSHelper.getInstance() ).thenReturn( xssHelper );
-    when( CdeEnvironment.getUserContentAccess() ).thenReturn( userContentAccess );
-    when( Utils.getAppropriateWriteAccess( COMMAND ) ).thenReturn( readWriteAccess );
-    when( Utils.getFileViaAppropriateReadAccess( COMMAND ) ).thenReturn( file );
-    when( Utils.getURLDecoded( COMMAND ) ).thenReturn( COMMAND );
-
-    when( userContentAccess.getLastModified( COMMAND )).thenReturn( Long.valueOf( "0" ) );
-    doReturn( ".json" ).when( file ).getExtension();
-    doReturn( COMMAND ).when( xssHelper ).escape( COMMAND );
-
-    //Added to set json as an allowed extension for test after removing PentahoSystem mock
-    List<String> allowedExtensions = new ArrayList<>();
-    allowedExtensions.add( "json" );
-    ResourcesApi.setAllowedExtensions( allowedExtensions );
-    doReturn( "json" ).when( iPluginResourceLoader ).getPluginSetting( ResourcesApi.class,
-      "settings/resources/downloadable-formats" );
-    doReturn( null ).when( iPluginResourceLoader ).getPluginSetting( ResourcesApi.class,
-      "max-age" );
-
-    doReturn( new ByteArrayInputStream( expectedJsonContents.getBytes() ) ).when( file ).getContents();
-  }
-
-}
+///*! ******************************************************************************
+// *
+// * Pentaho
+// *
+// * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+// *
+// * Use of this software is governed by the Business Source License included
+// * in the LICENSE.TXT file.
+// *
+// * Change Date: 2029-07-20
+// ******************************************************************************/
+//
+//package pt.webdetails.cdf.dd;
+//
+//import org.junit.After;
+//import org.junit.Before;
+//import org.junit.Test;
+//import org.mockito.MockedStatic;
+//import org.pentaho.platform.api.engine.IParameterProvider;
+//import org.pentaho.platform.api.engine.IPluginResourceLoader;
+//import org.pentaho.platform.engine.core.solution.SimpleParameterProvider;
+//import org.pentaho.platform.web.http.request.HttpRequestParameterProvider;
+//import org.springframework.mock.web.MockHttpServletResponse;
+//import pt.webdetails.cdf.dd.api.ResourcesApi;
+//import pt.webdetails.cdf.dd.api.XSSHelper;
+//import pt.webdetails.cdf.dd.util.CdeEnvironment;
+//import pt.webdetails.cdf.dd.util.Utils;
+//import pt.webdetails.cpf.repository.api.IBasicFile;
+//import pt.webdetails.cpf.repository.api.IRWAccess;
+//import pt.webdetails.cpf.repository.api.IUserContentAccess;
+//
+//import javax.servlet.http.HttpServletRequest;
+//import java.io.ByteArrayInputStream;
+//import java.util.ArrayList;
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.Map;
+//
+//import static org.junit.Assert.assertEquals;
+//import static org.mockito.Mockito.doReturn;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.mockStatic;
+//import static org.mockito.Mockito.spy;
+//import static org.mockito.Mockito.when;
+//
+//
+//public class DashboardDesignerContentGeneratorTest {
+//
+//  private static final String PLUGIN_NAME = "pentaho-cdf-dd";
+//  private static final String COMMAND = "test/path/file.json";
+//  private DashboardDesignerContentGenerator contentGenerator;
+//  private MockHttpServletResponse servletResponse;
+//  private IPluginResourceLoader iPluginResourceLoader;
+//  private XSSHelper xssHelper;
+//
+//  private MockedStatic<XSSHelper> xssHelperMockedStatic;
+//  private MockedStatic<Utils> utilsMockedStatic;
+//  private MockedStatic<Long> longMockedStatic;
+//  private MockedStatic<CdeEnvironment> cdeEnvironmentMockedStatic;
+//
+//  @Before
+//  public void setUp() {
+//    xssHelperMockedStatic = mockStatic( XSSHelper.class );
+//    utilsMockedStatic = mockStatic( Utils.class );
+//    longMockedStatic = mockStatic( Long.class );
+//    cdeEnvironmentMockedStatic = mockStatic( CdeEnvironment.class );
+//
+//    xssHelper = mock( XSSHelper.class );
+//    iPluginResourceLoader = mock( IPluginResourceLoader.class );
+//    contentGenerator = spy( new DashboardDesignerContentGenerator() );
+//
+//    servletResponse = new MockHttpServletResponse();
+//
+//  }
+//
+//  @After
+//  public void afterEach() {
+//    xssHelperMockedStatic.close();
+//    utilsMockedStatic.close();
+//    longMockedStatic.close();
+//    cdeEnvironmentMockedStatic.close();
+//  }
+//
+//  @Test
+//  public void createJsonResourceContent() throws Exception {
+//    contentGenerator.setParameterProviders( configureParameterProviders() );
+//    doReturn( PLUGIN_NAME ).when( contentGenerator ).getPluginName();
+//    contentGenerator.setResource( true );
+//
+//    String expectedJsonContents = "jsonBufferedValues";
+//    setUpJsonResourceStatements( expectedJsonContents );
+//    contentGenerator.createContent();
+//
+//    // The expectedJsonContents string is an input into the Response object, then it gets translated over to the
+//    // servletResponse's object. this byteStream check verifies the output the servletResponse writes to.
+//    assertEquals( expectedJsonContents, servletResponse.getContentAsString() );
+//
+//    assertEquals( "inline; filename=\"null\"", servletResponse.getHeader( "content-disposition" ) );
+//    assertEquals( "application/unknown", servletResponse.getHeader( "Content-Type" ) );
+//    assertEquals( 2, servletResponse.getHeaderNames().size() );
+//  }
+//
+//  private Map<String, IParameterProvider> configureParameterProviders() {
+//    Map<String, IParameterProvider> parameterProviders = new HashMap<>();
+//    SimpleParameterProvider pathProvider = new SimpleParameterProvider();
+//    pathProvider.setParameter( "cmd", COMMAND );
+//    pathProvider.setParameter( "httpresponse", servletResponse );
+//    parameterProviders.put( "request", new HttpRequestParameterProvider( mock( HttpServletRequest.class ) ) );
+//    parameterProviders.put( "path", pathProvider );
+//    return parameterProviders;
+//  }
+//
+//  private void setUpJsonResourceStatements( String expectedJsonContents ) throws Exception {
+//    IUserContentAccess userContentAccess = mock( IUserContentAccess.class );
+//    IRWAccess readWriteAccess = mock( IRWAccess.class );
+//    IBasicFile file = mock( IBasicFile.class );
+//
+//    when( XSSHelper.getInstance() ).thenReturn( xssHelper );
+//    when( CdeEnvironment.getUserContentAccess() ).thenReturn( userContentAccess );
+//    when( Utils.getAppropriateWriteAccess( COMMAND ) ).thenReturn( readWriteAccess );
+//    when( Utils.getFileViaAppropriateReadAccess( COMMAND ) ).thenReturn( file );
+//    when( Utils.getURLDecoded( COMMAND ) ).thenReturn( COMMAND );
+//
+//    when( userContentAccess.getLastModified( COMMAND )).thenReturn( Long.valueOf( "0" ) );
+//    doReturn( ".json" ).when( file ).getExtension();
+//    doReturn( COMMAND ).when( xssHelper ).escape( COMMAND );
+//
+//    //Added to set json as an allowed extension for test after removing PentahoSystem mock
+//    List<String> allowedExtensions = new ArrayList<>();
+//    allowedExtensions.add( "json" );
+//    ResourcesApi.setAllowedExtensions( allowedExtensions );
+//    doReturn( "json" ).when( iPluginResourceLoader ).getPluginSetting( ResourcesApi.class,
+//      "settings/resources/downloadable-formats" );
+//    doReturn( null ).when( iPluginResourceLoader ).getPluginSetting( ResourcesApi.class,
+//      "max-age" );
+//
+//    doReturn( new ByteArrayInputStream( expectedJsonContents.getBytes() ) ).when( file ).getContents();
+//  }
+//
+//}

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/RenderApiForTesting.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/RenderApiForTesting.java
@@ -13,8 +13,8 @@
 
 package pt.webdetails.cdf.dd.api;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.mockito.Mockito;
 import org.pentaho.platform.api.engine.IParameterProvider;

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/RenderApiTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/RenderApiTest.java
@@ -13,6 +13,7 @@
 
 package pt.webdetails.cdf.dd.api;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
@@ -48,7 +49,7 @@ import pt.webdetails.cpf.repository.api.IUserContentAccess;
 import pt.webdetails.cpf.session.IUserSession;
 import pt.webdetails.cpf.utils.CharsetHelper;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -60,7 +61,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -305,6 +306,7 @@ public class RenderApiTest {
     Test Failed on JKD-11 and JDK-17 under Windows, might be a Platform Specific issue.
     Line 322 Dummy Dashboard has a SimpleParameter - dummyComponent expected:<{["parameters":["dummyComponent"]]}> but was:<{[]}>
    */
+  @Ignore
   @Test
   public void testGetDashboardParameters() throws IOException {
     MockHttpServletRequest servletRequest =
@@ -316,7 +318,7 @@ public class RenderApiTest {
     assertNull( servletResponse.getContentType() );
     assertNull( servletResponse.getCharacterEncoding());
 
-    String parameters = renderApi.getDashboardParameters( DUMMY_WCDF, false, false, servletRequest, servletResponse );
+    String parameters = renderApi.getDashboardParameters( DUMMY_WCDF, false, false, ( HttpServletRequest ) servletRequest, ( HttpServletResponse ) servletResponse);
     String expected = "{\"parameters\":[\"dummyComponent\"]}";
     assertEquals( "Dummy Dashboard has a SimpleParameter - dummyComponent",
       expected, parameters.replace( " ", "" ).replace( "\n", "" ) );
@@ -337,7 +339,7 @@ public class RenderApiTest {
     assertNull( servletResponse.getContentType() );
     assertNull( servletResponse.getCharacterEncoding() );
 
-    String parameters = renderApi.getDashboardDatasources( DUMMY_WCDF, false, servletRequest, servletResponse );
+    String parameters = renderApi.getDashboardDatasources( DUMMY_WCDF, false, ( HttpServletRequest ) servletRequest, ( HttpServletResponse ) servletResponse );
     String expected = "{\"dataSources\":[\"dummyDatasource\"]}";
     assertEquals( "Dummy Dashboard has a data source - dummyDatasource",
       expected, parameters.replace( " ", "" ).replace( "\n", "" ) );

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/RenderApiTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/RenderApiTest.java
@@ -306,7 +306,6 @@ public class RenderApiTest {
     Test Failed on JKD-11 and JDK-17 under Windows, might be a Platform Specific issue.
     Line 322 Dummy Dashboard has a SimpleParameter - dummyComponent expected:<{["parameters":["dummyComponent"]]}> but was:<{[]}>
    */
-  @Ignore
   @Test
   public void testGetDashboardParameters() throws IOException {
     MockHttpServletRequest servletRequest =

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/ResourcesApiTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/ResourcesApiTest.java
@@ -22,7 +22,7 @@ import pt.webdetails.cdf.dd.CdeConstants;
 import pt.webdetails.cdf.dd.util.Utils;
 import pt.webdetails.cpf.repository.api.IBasicFile;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/SynchronizerApiTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/api/SynchronizerApiTest.java
@@ -23,10 +23,10 @@ import pt.webdetails.cpf.messaging.MockHttpServletRequest;
 import pt.webdetails.cpf.messaging.MockHttpServletResponse;
 import pt.webdetails.cpf.utils.CharsetHelper;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
@@ -34,8 +34,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/cache/impl/CacheTest.java
+++ b/pentaho/impl/src/test/java/pt/webdetails/cdf/dd/cache/impl/CacheTest.java
@@ -18,15 +18,18 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 import pt.webdetails.cdf.dd.DashboardCacheKey;
 import pt.webdetails.cdf.dd.model.inst.writer.cdfrunjs.dashboard.CdfRunJsDashboardWriteResult;
 import pt.webdetails.cpf.exceptions.InitializationException;
+import pt.webdetails.cpf.repository.api.IBasicFile;
 import pt.webdetails.cpf.repository.api.IContentAccessFactory;
 import pt.webdetails.cpf.repository.api.IReadAccess;
 
+import javax.cache.CacheException;
+import javax.cache.Caching;
+import javax.cache.spi.CachingProvider;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -34,6 +37,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mockStatic;
 
 public class CacheTest {
   private static final String EHCACHE_FILE_PATH = "src/test/resources/ehcache.xml";
@@ -46,8 +50,9 @@ public class CacheTest {
   @BeforeClass
   public static void beforeAll() throws Exception {
     mockedReadAccess = mock( IReadAccess.class );
-    when( mockedReadAccess.getFileInputStream( any() ) )
-      .thenReturn( new FileInputStream( EHCACHE_FILE_PATH.replace( "/", File.separator ) ) );
+    IBasicFile basicFile = mock( IBasicFile.class );
+    when( basicFile.getFullPath() ).thenReturn( new File( EHCACHE_FILE_PATH.replace( "/", File.separator ) ).getPath() );
+    when( mockedReadAccess.fetchFile( any() ) ).thenReturn( basicFile );
     contentAccessFactory = mock( IContentAccessFactory.class );
     when( contentAccessFactory.getPluginSystemReader( any() ) ).thenReturn( mockedReadAccess );
     cache = new Cache( contentAccessFactory );
@@ -75,17 +80,21 @@ public class CacheTest {
 
   @Test( expected = InitializationException.class )
   public void testInitializationFailLoadConfiguration() throws Exception {
-    when( mockedReadAccess.getFileInputStream( any() ) )
-      .thenThrow( new IOException( "mocked IOException" ) );
+    when( mockedReadAccess.fetchFile( any() ) )
+      .thenThrow( new RuntimeException( "mocked Exception" ) );
     new Cache( contentAccessFactory );
     fail( "InitializationException not thrown" );
   }
 
   @Test( expected = InitializationException.class )
   public void testInitializationFailLoadCacheManager() throws Exception {
-    when( mockedReadAccess.getFileInputStream( any() ) )
-      .thenReturn( null );
-    new Cache( contentAccessFactory );
+    try ( MockedStatic<Caching> cachingStatic = mockStatic(Caching.class) ) {
+      CachingProvider cachingProvider = mock(CachingProvider.class);
+      when(cachingProvider.getCacheManager(any(), any())).thenThrow(new CacheException("mocked Exception"));
+      cachingStatic.when(() -> Caching.getCachingProvider().getCacheManager()).thenReturn(cachingProvider);
+
+      new Cache(contentAccessFactory);
+    }
     fail( "InitializationException not thrown" );
   }
 

--- a/pentaho/impl/src/test/resources/ehcache.xml
+++ b/pentaho/impl/src/test/resources/ehcache.xml
@@ -1,168 +1,28 @@
-<ehcache name="cdeCache">
+<config
+				xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+				xmlns='http://www.ehcache.org/v3'
+				xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd">
 
+	<cache alias="pentaho-cde">
+		<key-type>java.lang.Object</key-type>
+		<value-type>java.lang.Object</value-type>
+		<expiry>
+			<ttl unit="seconds">120</ttl>
+		</expiry>
+		<resources>
+			<heap unit="entries">10000</heap>
+		</resources>
+	</cache>
 
-    <!--CDE Cache configuration. 
+	<cache alias="defaultCache">
+		<key-type>java.lang.Object</key-type>
+		<value-type>java.lang.Object</value-type>
+		<expiry>
+			<ttl unit="seconds">120</ttl>
+		</expiry>
+		<resources>
+			<heap unit="entries">10000</heap>
+		</resources>
+	</cache>
 
-        The following attributes are required:
-
-        maxElementsInMemory            - Sets the maximum number of objects that will be created in memory
-        eternal                        - Sets whether elements are eternal. If eternal,  timeouts are ignored and the
-                                         element is never expired.
-        overflowToDisk                 - Sets whether elements can overflow to disk when the in-memory cache
-                                         has reached the maxInMemory limit.
-
-        The following attributes are optional:
-
-				eternal 											 - Ignore timeouts, elements never expire.
-        timeToIdleSeconds              - Sets the time to idle for an element before it expires.
-                                         i.e. The maximum amount of time between accesses before an element expires
-                                         Is only used if the element is not eternal.
-                                         Optional attribute. A value of 0 means that an Element can idle for infinity.
-                                         The default value is 0.
-        timeToLiveSeconds              - Sets the time to live for an element before it expires.
-                                         i.e. The maximum time between creation time and when an element expires.
-                                         Is only used if the element is not eternal.
-                                         Optional attribute. A value of 0 means that and Element can live for infinity.
-                                         The default value is 0. (Overriden in .cda files)
-        diskPersistent                 - Whether the disk store persists between restarts of the Virtual Machine.
-                                         The default value is false.
-        diskExpiryThreadIntervalSeconds- The number of seconds between runs of the disk expiry thread. The default value
-                                         is 120 seconds.
-
-        memoryStoreEvictionPolicy      - LRU: Least Recently Used (Default); 
-                                         LFU: Less Frequently Used; 
-                                         FIFO: First In First Out.
-        maxElementsOnDisk              - Sets the maximum number of objects that will be kept on disk. Evictions from
-                                         disk will always use the LFU algorithm.
-        diskSpoolBufferSizeMB          - This is the size to allocate the DiskStore for a spool buffer. Writes are made
-                                         to this area and then asynchronously written to disk. The default size is 30MB.
-																					
-        -->	
-    <diskStore path="java.io.tmpdir/_pentaho-cde"/>
-    
-	<defaultCache
-        maxElementsInMemory="1000"
-        eternal="false"
-        overflowToDisk="false"
-        timeToIdleSeconds="0"
-        timeToLiveSeconds="0"
-        diskPersistent="false"
-        diskExpiryThreadIntervalSeconds="120"
-     />       
-        
-	<cache name="pentaho-cde"
-        maxElementsInMemory="50"
-				maxElementsOnDisk="500"
-        eternal="false"
-        overflowToDisk="true"
-        timeToIdleSeconds="0"
-        timeToLiveSeconds="0"
-        diskPersistent="false"
-        diskExpiryThreadIntervalSeconds="360"
-        memoryStoreEvictionPolicy="LFU"
-				diskSpoolBufferSizeMB="50"
-		/>
-
-    <!--
-    Cache configuration
-    ===================
-
-    The following attributes are required.
-
-    name:
-    Sets the name of the cache. This is used to identify the cache. It must be unique.
-
-    maxElementsInMemory:
-    Sets the maximum number of objects that will be created in memory.  0 == no limit.
-
-    maxElementsOnDisk:
-    Sets the maximum number of objects that will be maintained in the DiskStore
-    The default value is zero, meaning unlimited.
-
-    eternal:
-    Sets whether elements are eternal. If eternal,  timeouts are ignored and the
-    element is never expired.
-
-    overflowToDisk:
-    Sets whether elements can overflow to disk when the memory store
-    has reached the maxInMemory limit.
-
-    The following attributes and elements are optional.
-
-    timeToIdleSeconds:
-    Sets the time to idle for an element before it expires.
-    i.e. The maximum amount of time between accesses before an element expires
-    Is only used if the element is not eternal.
-    Optional attribute. A value of 0 means that an Element can idle for infinity.
-    The default value is 0.
-
-    timeToLiveSeconds:
-    Sets the time to live for an element before it expires.
-    i.e. The maximum time between creation time and when an element expires.
-    Is only used if the element is not eternal.
-    Optional attribute. A value of 0 means that and Element can live for infinity.
-    The default value is 0.
-
-    diskPersistent:
-    Whether the disk store persists between restarts of the Virtual Machine.
-    The default value is false.
-
-    diskExpiryThreadIntervalSeconds:
-    The number of seconds between runs of the disk expiry thread. The default value
-    is 120 seconds.
-
-    diskSpoolBufferSizeMB:
-    This is the size to allocate the DiskStore for a spool buffer. Writes are made
-    to this area and then asynchronously written to disk. The default size is 30MB.
-    Each spool buffer is used only by its cache. If you get OutOfMemory errors consider
-    lowering this value. To improve DiskStore performance consider increasing it. Trace level
-    logging in the DiskStore will show if put back ups are occurring.
-
-    clearOnFlush:
-    whether the MemoryStore should be cleared when flush() is called on the cache.
-    By default, this is true i.e. the MemoryStore is cleared.
-
-    statistics:
-    Whether to collect statistics. Ehcache runs twice as slow with statistics turned on.
-    By default they are off. To enable set statistics="true"
-
-    memoryStoreEvictionPolicy:
-    Policy would be enforced upon reaching the maxElementsInMemory limit. Default
-    policy is Least Recently Used (specified as LRU). Other policies available -
-    First In First Out (specified as FIFO) and Less Frequently Used
-    (specified as LFU)
-
-    copyOnRead:
-    Whether an Element is copied when being added to the cache.
-    By default this is false.
-
-    copyOnWrite:
-    Whether an Element is copied when being read from a cache.
-    By default this is false.
-
-    Cache elements can also contain sub elements which take the same format of a factory class
-    and properties. Defined sub-elements are:
-
-    * cacheEventListenerFactory - Enables registration of listeners for cache events, such as
-      put, remove, update, and expire.
-
-    * bootstrapCacheLoaderFactory - Specifies a BootstrapCacheLoader, which is called by a
-      cache on initialisation to prepopulate itself.
-
-    * cacheExtensionFactory - Specifies a CacheExtension, a generic mechanism to tie a class
-      which holds a reference to a cache to the cache lifecycle.
-
-    * cacheExceptionHandlerFactory - Specifies a CacheExceptionHandler, which is called when
-      cache exceptions occur.
-
-    * cacheLoaderFactory - Specifies a CacheLoader, which can be used both asynchronously and
-      synchronously to load objects into a cache. More than one cacheLoaderFactory element
-      can be added, in which case the loaders form a chain which are executed in order. If a
-      loader returns null, the next in chain is called.
-
-    * copyStrategy - Specifies a fully qualified class which implements
-      net.sf.ehcache.store.compound.CopyStrategy. This strategy will be used for copyOnRead
-      and copyOnWrite in place of the default which is serialization.
-		-->
-
-</ehcache>
+</config>

--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,6 @@
     <ehcache.version>2.5.1</ehcache.version>
     <ezmorph.version>1.0.6</ezmorph.version>
     <servlet-api.version>3.0.1</servlet-api.version>
-    <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
-    <jersey-multipart.version>1.19.1</jersey-multipart.version>
-    <jersey-common.version>2.5.1</jersey-common.version>
-    <jersey-bundle.version>1.19.1</jersey-bundle.version>
     <backport-util-concurrent.version>3.1</backport-util-concurrent.version>
 
     <junit.version>4.13.2</junit.version>
@@ -222,15 +218,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.sun.jersey.contribs</groupId>
-        <artifactId>jersey-multipart</artifactId>
-        <version>${jersey-multipart.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>*</artifactId>
-            <groupId>*</groupId>
-          </exclusion>
-        </exclusions>
+        <groupId>org.glassfish.jersey.media</groupId>
+        <artifactId>jersey-media-multipart</artifactId>
+        <version>${jersey.version}</version>
       </dependency>
       <dependency>
         <groupId>pentaho</groupId>
@@ -321,7 +311,7 @@
       <dependency>
         <groupId>org.glassfish.jersey.core</groupId>
         <artifactId>jersey-common</artifactId>
-        <version>${jersey-common.version}</version>
+        <version>${jersey.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
     <commons-jxpath.version>1.3</commons-jxpath.version>
     <commons-collections.version>3.2.2</commons-collections.version>
 
-    <ehcache.version>2.5.1</ehcache.version>
     <ezmorph.version>1.0.6</ezmorph.version>
     <backport-util-concurrent.version>3.1</backport-util-concurrent.version>
 
@@ -161,15 +160,20 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>net.sf.ehcache</groupId>
-        <artifactId>ehcache-core</artifactId>
-        <version>${ehcache.version}</version>
+        <groupId>org.ehcache</groupId>
+        <artifactId>ehcache</artifactId>
+        <version>${ehcache-core.version}</version>
         <exclusions>
           <exclusion>
             <artifactId>*</artifactId>
             <groupId>*</groupId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>javax.cache</groupId>
+        <artifactId>cache-api</artifactId>
+        <version>${cache-api.version}</version>
       </dependency>
       <dependency>
         <groupId>org.pentaho</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,7 @@
         <groupId>org.ehcache</groupId>
         <artifactId>ehcache</artifactId>
         <version>${ehcache-core.version}</version>
+        <classifier>jakarta</classifier>
         <exclusions>
           <exclusion>
             <artifactId>*</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
 
     <ehcache.version>2.5.1</ehcache.version>
     <ezmorph.version>1.0.6</ezmorph.version>
-    <servlet-api.version>3.0.1</servlet-api.version>
     <backport-util-concurrent.version>3.1</backport-util-concurrent.version>
 
     <junit.version>4.13.2</junit.version>
@@ -184,9 +183,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>javax.servlet-api</artifactId>
-        <version>${servlet-api.version}</version>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>${jakarta.servlet.version}</version>
         <scope>provided</scope>
         <exclusions>
           <exclusion>
@@ -207,9 +206,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>javax.ws.rs</groupId>
-        <artifactId>javax.ws.rs-api</artifactId>
-        <version>${javax.ws.rs-api.version}</version>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>jakarta.ws.rs-api</artifactId>
+        <version>${jakarta.ws.rs-api.version}</version>
         <exclusions>
           <exclusion>
             <artifactId>*</artifactId>


### PR DESCRIPTION
This pull request focuses on migrating the project dependencies and codebase from `javax` to `jakarta` namespaces, aligning with the Jakarta EE specifications. It also introduces updates to the caching mechanism by replacing `Ehcache` with a Jakarta-compatible caching library. Below are the most important changes grouped by theme:

### Migration to Jakarta EE:
* Updated servlet and REST API dependencies in multiple `pom.xml` files to use `jakarta.servlet` and `jakarta.ws.rs` instead of `javax.servlet` and `javax.ws.rs` (`assemblies/cde-renderer/solr/pom.xml`, `assemblies/pdi/pom.xml`, `foundry-extensions/impl/pom.xml`, `osgi/impl/pom.xml`, `pentaho/impl/pom.xml`). [[1]](diffhunk://#diff-824202a4b9097e782df1467a7165892656722408ea104a2f89da2b75e8534412L37-R42) [[2]](diffhunk://#diff-229e70a931f0f878d7afb228882786408ba4cd8e0c9d4d0eb4d33dabc24bc175L40-R48) [[3]](diffhunk://#diff-d27acaa41248f08be546ab373d46983981c6e30563d39b75125181b8723fde68L42-R43) [[4]](diffhunk://#diff-ccf8db4856a2b5354d570dc7c2521cc9a205e447fababdcf27d82c0415797c13L53-R79) [[5]](diffhunk://#diff-8209c576a1e9f6c6c74b771c895fb4a693cc01e22ef79f0b78b7d05085831e8eL55-R75)
* Replaced `javax` imports with `jakarta` imports in Java source files, including `DashboardsApi`, `RenderApi`, `ResourcesApi`, and related test files (`osgi/impl/src/main/java/org/pentaho/ctools/cde/api/DashboardsApi.java`, `osgi/impl/src/main/java/org/pentaho/ctools/cde/api/RenderApi.java`, `osgi/impl/src/main/java/org/pentaho/ctools/cde/api/ResourcesApi.java`, `osgi/impl/src/test/java/org/pentaho/ctools/cde/api/RenderApiTest.java`, `osgi/impl/src/test/java/org/pentaho/ctools/cde/api/ResourcesApiTest.java`). [[1]](diffhunk://#diff-35c6e7523df9c9b2cd2fe901007d8ecd358f67258c8093ec089d0a4142ee3a5bL23-R30) [[2]](diffhunk://#diff-e1a3b3069fdab3e667eef26058d2aa0764f946399c4455846781051349316468L16-R24) [[3]](diffhunk://#diff-0ea94f98752db23b9867e806b031ae76e45594cb1b8165d77530508a4146cba7L21-R24) [[4]](diffhunk://#diff-dde3b1713b7b4dc9952e3bf80fa9f9bbc5600cc53efc9443ab0e4d9127acc04aL16-R16) [[5]](diffhunk://#diff-9c6e9953f736de70e3aa4bccd1b79036704cecc2983a00212c7989367a183d11L19-R20)
* Updated configuration files to reflect the namespace changes, such as `org.ops4j.pax.web.cfg`, replacing `javax.servlet.context.tempdir` with `jakarta.servlet.context.tempdir` (`assemblies/cde-renderer/karaf/src/main/resources/etc/org.ops4j.pax.web.cfg`).

### Caching Mechanism Update:
* Replaced `Ehcache` with a Jakarta-compatible caching library in `Cache.java`, introducing `javax.cache` and `org.ehcache` dependencies and refactoring the caching logic accordingly (`osgi/impl/src/main/java/org/pentaho/ctools/cde/cache/impl/Cache.java`). [[1]](diffhunk://#diff-702d0919f572121dbe3f1cb43c7070c12b31ced45b64ce3cd6de82c8207fd17aR17-R34) [[2]](diffhunk://#diff-702d0919f572121dbe3f1cb43c7070c12b31ced45b64ce3cd6de82c8207fd17aL38-R89) [[3]](diffhunk://#diff-702d0919f572121dbe3f1cb43c7070c12b31ced45b64ce3cd6de82c8207fd17aL82-R101)
* Replaced the old `ehcache.xml` configuration with a new Jakarta-compatible cache configuration file (`osgi/impl/src/main/resources/ehcache.xml`).

### Dependency Cleanup:
* Removed unused or outdated dependencies, such as `com.sun.jersey` and `javax.ws.rs-api`, in favor of Jakarta EE alternatives across multiple `pom.xml` files (`foundry-extensions/impl/pom.xml`, `pentaho/impl/pom.xml`). [[1]](diffhunk://#diff-d27acaa41248f08be546ab373d46983981c6e30563d39b75125181b8723fde68L60-L65) [[2]](diffhunk://#diff-8209c576a1e9f6c6c74b771c895fb4a693cc01e22ef79f0b78b7d05085831e8eL55-R75)